### PR TITLE
ci: Github Action 설정 추가

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,37 @@
+name: Test and Build
+
+on: [push, pull_request, pull_request_target]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Check formatting
+        run: ./gradlew ktlintCheck
+      - name: Run unit test
+        run: ./gradlew test
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Package
+          path: build/libs
+      - name: Cleanup Gradle Cache
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation("io.r2dbc:r2dbc-postgresql")
     runtimeOnly("org.postgresql:postgresql")
-    testImplementation("junit:junit:4.12")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
 }

--- a/src/test/kotlin/com/kroffle/knitting/router/DesignRouterTests.kt
+++ b/src/test/kotlin/com/kroffle/knitting/router/DesignRouterTests.kt
@@ -6,21 +6,21 @@ import com.kroffle.knitting.domain.DesignType
 import com.kroffle.knitting.domain.PatternType
 import com.kroffle.knitting.handler.DesignHandler
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Flux
 import java.time.LocalDateTime
 import java.util.UUID
 
 @WebFluxTest
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class DesignRouterTests {
     @MockBean
     lateinit var repo: DesignRepository
@@ -31,7 +31,7 @@ class DesignRouterTests {
 
     private lateinit var now: LocalDateTime
 
-    @Before
+    @BeforeEach
     fun setUp() {
         now = LocalDateTime.now()
         design = Design(

--- a/src/test/kotlin/com/kroffle/knitting/router/PingRouterTests.kt
+++ b/src/test/kotlin/com/kroffle/knitting/router/PingRouterTests.kt
@@ -1,20 +1,20 @@
 package com.kroffle.knitting.router
 
 import com.kroffle.knitting.handler.PingHandler
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 
 @WebFluxTest
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class PingRouterTests {
     lateinit var webClient: WebTestClient
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val routerFunction = PingRouter(PingHandler()).pingRouterFunction()
         webClient = WebTestClient.bindToRouterFunction(routerFunction).build()


### PR DESCRIPTION
## PR 제안 사유
resolves #12 

테스트와 린트, 빌드를 자동화하기 위해 github action 을 추가합니다.
빌드가 완료된 결과물은 artifacts로 저장합니다.

추가로 gradlew로 실행하기위해서 junit5가 아니라 4로 구현되어있는 테스트를 고쳐주었습니다.

### 참고 문서
- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
- https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle

## 주요 변경 기록
- github action 파일 추가


## 특이사항

ktlint와 테스트 코드가 있는 상태에서 작업해야 했기 때문에
https://github.com/k-roffle/knitting-service/pull/11 해당 PR을 베이스로 작업해주었습니다.
마지막 커밋 3개만 리뷰해주시면 됩니다!