### PR TITLE
ci: remove pull_request_target trigger option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Test and Build
 
-on: [push, pull_request, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION

## PR 제안 사유

이전에 작업할 때 PR을 올려도 github action 이 안 돌아서 pull_request_target을 추가했었는데, 
main에 머지되기 전이여서 그런 것으로 보입니다.

https://github.com/k-roffle/knitting-service/pull/15 PR을 올렸을 때 동일한 CI가 2번 돌게되어서 pull_request_target trigger를 지웁니다.
