### PR TITLE
Refactor: 아키텍쳐 수정

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/design/DesignRouter.kt
@@ -1,6 +1,6 @@
-package com.kroffle.knitting.presentation.router.design
+package com.kroffle.knitting.controller.design
 
-import com.kroffle.knitting.domain.handler.design.DesignHandler
+import com.kroffle.knitting.usecase.design.DesignHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RequestPredicates.path

--- a/src/main/kotlin/com/kroffle/knitting/controller/ping/PingRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/ping/PingRouter.kt
@@ -1,6 +1,6 @@
-package com.kroffle.knitting.presentation.router.ping
+package com.kroffle.knitting.controller.ping
 
-import com.kroffle.knitting.domain.handler.ping.PingHandler
+import com.kroffle.knitting.usecase.ping.PingHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RequestPredicates.path

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/DatabaseProperties.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/DatabaseProperties.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.data.configuration
+package com.kroffle.knitting.infra.configuration
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
@@ -1,7 +1,7 @@
-package com.kroffle.knitting.data.configuration
+package com.kroffle.knitting.infra.configuration
 
-import com.kroffle.knitting.data.entity.design.DesignType
-import com.kroffle.knitting.data.entity.design.PatternType
+import com.kroffle.knitting.infra.design.DesignType
+import com.kroffle.knitting.infra.design.PatternType
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration
 import io.r2dbc.postgresql.PostgresqlConnectionFactory
 import io.r2dbc.postgresql.codec.EnumCodec

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/DesignEntity.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.data.entity.design
+package com.kroffle.knitting.infra.design
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/DesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/DesignRepository.kt
@@ -1,6 +1,5 @@
-package com.kroffle.knitting.data.repository.design
+package com.kroffle.knitting.infra.design
 
-import com.kroffle.knitting.data.entity.design.DesignEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 
 interface DesignRepository : ReactiveCrudRepository<DesignEntity, Long>

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/DesignType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/DesignType.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.data.entity.design
+package com.kroffle.knitting.infra.design
 
 enum class DesignType(val code: Int) {
     Sweater(1),

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/PatternType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/PatternType.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.data.entity.design
+package com.kroffle.knitting.infra.design
 
 enum class PatternType(val code: Int) {
     Text(1),

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/SizeEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/SizeEntity.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.data.entity.design
+package com.kroffle.knitting.infra.design
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.usecase.design
 
+// FIXME: 의존성 룰 위반 knitting-service/#22
 import com.kroffle.knitting.infra.design.DesignRepository
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
@@ -1,6 +1,6 @@
-package com.kroffle.knitting.domain.handler.design
+package com.kroffle.knitting.usecase.design
 
-import com.kroffle.knitting.data.repository.design.DesignRepository
+import com.kroffle.knitting.infra.design.DesignRepository
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest

--- a/src/main/kotlin/com/kroffle/knitting/usecase/ping/PingHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/ping/PingHandler.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.domain.handler.ping
+package com.kroffle.knitting.usecase.ping
 
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component

--- a/src/test/kotlin/com/kroffle/knitting/controller/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/design/DesignRouterTest.kt
@@ -1,10 +1,10 @@
-package com.kroffle.knitting.presentation.router.design
+package com.kroffle.knitting.controller.design
 
-import com.kroffle.knitting.data.entity.design.DesignEntity
-import com.kroffle.knitting.data.entity.design.DesignType
-import com.kroffle.knitting.data.entity.design.PatternType
-import com.kroffle.knitting.data.repository.design.DesignRepository
-import com.kroffle.knitting.domain.handler.design.DesignHandler
+import com.kroffle.knitting.infra.design.DesignEntity
+import com.kroffle.knitting.infra.design.DesignRepository
+import com.kroffle.knitting.infra.design.DesignType
+import com.kroffle.knitting.infra.design.PatternType
+import com.kroffle.knitting.usecase.design.DesignHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/kroffle/knitting/controller/ping/PingRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/ping/PingRouterTest.kt
@@ -1,6 +1,6 @@
-package com.kroffle.knitting.presentation.router.ping
+package com.kroffle.knitting.controller.ping
 
-import com.kroffle.knitting.domain.handler.ping.PingHandler
+import com.kroffle.knitting.usecase.ping.PingHandler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith


### PR DESCRIPTION
## PR 제안 사유

바꾸고자 하는 아키텍쳐에 대한 내용은 #23 이슈에 자세히 적어두었습니다.
현재 코드에서는 Design 리스트 API 부분에 의해 dependency rule에 위배되는 부분이 있는데 해당 작업은 #22 에서 진행할 예정입니다.

resolves: #23 

### 파일 트리
```
src
├── main
│   ├── java
│   ├── kotlin
│   │   └── com
│   │       └── kroffle
│   │           └── knitting
│   │               ├── KnittingApplication.kt
│   │               ├── controller
│   │               │   ├── design
│   │               │   │   └── DesignRouter.kt
│   │               │   └── ping
│   │               │       └── PingRouter.kt
│   │               ├── domain
│   │               │   └── design
│   │               ├── infra
│   │               │   ├── configuration
│   │               │   │   ├── DatabaseProperties.kt
│   │               │   │   └── R2dbcConfiguration.kt
│   │               │   └── design
│   │               │       ├── DesignEntity.kt
│   │               │       ├── DesignRepository.kt
│   │               │       ├── DesignType.kt
│   │               │       ├── PatternType.kt
│   │               │       └── SizeEntity.kt
│   │               └── usecase
│   │                   ├── design
│   │                   │   ├── DesignHandler.kt
│   │                   │   └── DesignRepository.kt
│   │                   └── ping
│   │                       └── PingHandler.kt
│   └── resources
│       ├── application.properties
│       └── db
│           └── migration
│               ├── V1__Initial.sql
│               └── V2__add_size_and_pattern_column_to_design.sql
└── test
    ├── java
    └── kotlin
        └── com
            └── kroffle
                └── knitting
                    └── controller
                        ├── design
                        │   └── DesignRouterTest.kt
                        └── ping
                            └── PingRouterTest.kt

29 directories, 18 files

```

## 주요 변경 기록
- 모듈 네이밍 및 파일 위치 변경
