### PR TITLE
feat: 도안 생성 API validation 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class Design(
-    val id: UUID,
+    val id: UUID? = null,
     val name: String,
     val designType: DesignType,
     val patternType: PatternType,
@@ -21,5 +21,5 @@ class Design(
     val extra: String?,
     val price: Money,
     val pattern: Pattern,
-    val createdAt: LocalDateTime,
+    val createdAt: LocalDateTime?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/value/Length.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/value/Length.kt
@@ -2,4 +2,8 @@ package com.kroffle.knitting.domain.design.value
 
 import com.kroffle.knitting.domain.design.enum.SizeUnitType
 
-class Length(val value: Double, val unit: SizeUnitType = SizeUnitType.Cm)
+class Length(val value: Double, val unit: SizeUnitType = SizeUnitType.Cm) {
+    init {
+        require(value > 0)
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/R2dbcDesignRepository.kt
@@ -14,9 +14,8 @@ class R2dbcDesignRepository(private val dbDesignRepository: DBDesignRepository) 
                 it.toDesign()
             }
 
-    override fun createDesign(design: Mono<Design>): Mono<Design> {
-        return design
-            .flatMap { dbDesignRepository.save(it.toDesignEntity()) }
+    override fun createDesign(design: Design): Mono<Design> =
+        dbDesignRepository
+            .save(design.toDesignEntity())
             .map { it.toDesign() }
-    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/design/entity/DesignEntity.kt
@@ -9,15 +9,13 @@ import com.kroffle.knitting.domain.design.value.Money
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import org.springframework.data.annotation.Id
-import org.springframework.data.annotation.Transient
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Table("design")
 class DesignEntity(
-    @Id private val id: UUID = UUID.randomUUID(),
+    @Id private var id: UUID?,
     private val name: String,
     private val designType: DesignType,
     private val patternType: PatternType,
@@ -34,16 +32,7 @@ class DesignEntity(
     private val price: Int = 0,
     private val pattern: String,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
-    @Transient private val isNew: Boolean = true,
-) : Persistable<UUID> {
-    override fun isNew(): Boolean {
-        return isNew
-    }
-
-    override fun getId(): UUID {
-        return this.id
-    }
-
+) {
     fun toDesign(): Design =
         Design(
             id = this.id,
@@ -85,5 +74,5 @@ fun Design.toDesignEntity() =
         extra = this.extra,
         price = this.price.value,
         pattern = this.pattern.value,
-        createdAt = this.createdAt,
+        createdAt = this.createdAt ?: LocalDateTime.now(),
     )

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
@@ -29,7 +29,10 @@ class DesignHandler(private val repository: DesignRepository) {
             }
 
     fun createDesign(req: ServerRequest): Mono<ServerResponse> {
-        val design: Mono<Design> = req.bodyToMono(Design::class.java).doOnNext { validate(it) }
+        val design: Mono<Design> = req
+            .bodyToMono(Design::class.java)
+            .switchIfEmpty(Mono.error(ServerWebInputException("Body is required")))
+            .doOnNext { validate(it) }
         return design
             .flatMap { repository.createDesign(it) }
             .flatMap {

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignHandler.kt
@@ -3,15 +3,21 @@ package com.kroffle.knitting.usecase.design
 import com.kroffle.knitting.domain.design.entity.Design
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Errors
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.ServerResponse.ok
+import org.springframework.web.server.ServerWebInputException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList
 
 @Component
 class DesignHandler(private val repository: DesignRepository) {
+
+    private val validator = DesignValidator()
+
     fun getAll(req: ServerRequest): Mono<ServerResponse> =
         repository
             .getAll()
@@ -22,17 +28,27 @@ class DesignHandler(private val repository: DesignRepository) {
                     .bodyValue(it)
             }
 
-    fun createDesign(req: ServerRequest): Mono<ServerResponse> =
-        repository
-            .createDesign(req.bodyToMono(Design::class.java))
+    fun createDesign(req: ServerRequest): Mono<ServerResponse> {
+        val design: Mono<Design> = req.bodyToMono(Design::class.java).doOnNext { validate(it) }
+        return design
+            .flatMap { repository.createDesign(it) }
             .flatMap {
                 ok()
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(it)
             }
+    }
 
     interface DesignRepository {
         fun getAll(): Flux<Design>
-        fun createDesign(design: Mono<Design>): Mono<Design>
+        fun createDesign(design: Design): Mono<Design>
+    }
+
+    private fun validate(design: Design) {
+        val errors: Errors = BeanPropertyBindingResult(design, "design")
+        validator.validate(design, errors)
+        if (errors.hasErrors()) {
+            throw ServerWebInputException(errors.toString())
+        }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignValidator.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignValidator.kt
@@ -1,0 +1,17 @@
+package com.kroffle.knitting.usecase.design
+
+import com.kroffle.knitting.domain.design.entity.Design
+import org.springframework.validation.Errors
+import org.springframework.validation.Validator
+
+class DesignValidator : Validator {
+    override fun supports(clazz: Class<*>): Boolean =
+        Design::class.java == clazz
+
+    override fun validate(target: Any, errors: Errors) {
+        val designInput = target as Design
+        if (designInput.price.value < 0) {
+            errors.rejectValue("price", "negative_price")
+        }
+    }
+}

--- a/src/main/resources/db/migration/V4__add_default_value.sql
+++ b/src/main/resources/db/migration/V4__add_default_value.sql
@@ -1,0 +1,1 @@
+ALTER TABLE design ALTER COLUMN id SET DEFAULT uuid_generate_v4();

--- a/src/test/kotlin/com/kroffle/knitting/controller/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/design/DesignRouterTest.kt
@@ -20,7 +20,6 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
-import java.time.LocalDateTime
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -38,6 +37,7 @@ class DesignRouterTest {
     @BeforeEach
     fun setUp() {
         design = DesignEntity(
+            id = null,
             name = "test",
             designType = DesignType.Sweater,
             patternType = PatternType.Text,
@@ -53,7 +53,6 @@ class DesignRouterTest {
             extra = null,
             price = 0,
             pattern = "# Step1. 코를 10개 잡습니다.",
-            createdAt = LocalDateTime.now(),
         ).toDesign()
 
         val routerFunction = DesignRouter(DesignHandler(repo)).designRouterFunction()
@@ -68,6 +67,7 @@ class DesignRouterTest {
             .post()
             .uri("/design/")
             .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(body)
             .exchange()
             .expectStatus()

--- a/src/test/kotlin/com/kroffle/knitting/controller/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/design/DesignsRouterTest.kt
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Flux
 import java.time.LocalDateTime
+import java.util.UUID
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -37,6 +38,7 @@ class DesignsRouterTest {
     @BeforeEach
     fun setUp() {
         design = DesignEntity(
+            id = UUID.randomUUID(),
             name = "test",
             designType = DesignType.Sweater,
             patternType = PatternType.Text,


### PR DESCRIPTION
## PR 제안 사유
resolves #29 

API에 validation을 추가하고, id와 생성 시각을 클라이언트에서 만들어줘야하던 부분을 수정합니다.
추가로 body가 비어있을 때 에러처리를 하고 있지 않던 부분도 수정합니다.

이제 아래처럼 body에 담아서 요청하면 됩니다!
yarn과 extra는 입력값 중 일부이긴 해서 default값 없이 명시적으로 적어주도록 했어요!

```
{
    "name": "새로운 도안!",
    "designType": "Sweater",
    "patternType": "Text",
    "gauge": {
        "stitches": 15.2,
        "rows": 0
    },
    "size": {
        "totalLength": {
            "value": 10.5,
            "unit": "Cm"
        },
        "sleeveLength": {
            "value": 1.2,
            "unit": "Cm"
        },
        "shoulderWidth": {
            "value": 14.2,
            "unit": "Cm"
        },
        "bottomWidth": {
            "value": 12.2,
            "unit": "Cm"
        },
        "armholeDepth": {
            "value": 162,
            "unit": "Cm"
        }
    },
    "needle": "바늘바늘",
    "yarn": null,
    "extra": null,
    "price": {
        "value": 0
    },
    "pattern": {
        "value": "뜨는 방법"
    }
}
```

https://github.com/k-roffle/knitting-service/pull/33 를 베이스로 작업했고 마지막 6개만 리뷰봐주시면 됩니다.


## 주요 변경 기록

- Design.id에 default value 추가
  - isNew 직접 구현해주는 부분 삭제 
  - 이제 entity instance의 id가 비어있다면 isNew가 true, 채워져있다면 false 로 동일하고, isNew에 따라서 update할지 insert할지 내부적으로 결정하게 됩니다
- Design Validator를 구현했습니당
