### PR TITLE
feat: private API의 경우 접근시 헤더를 체크할 수 있도록 구현합니다.

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/ExpiredTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/ExpiredTokenException.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.exception.auth
+
+class ExpiredTokenException : UnauthorizedException("Token is expired.")

--- a/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/InvalidBodyTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/InvalidBodyTokenException.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.exception.auth
+
+class InvalidBodyTokenException : UnauthorizedException("Token had invalid body format.")

--- a/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/UnauthorizedException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.exception.auth
+
+abstract class UnauthorizedException(message: String) : Exception(message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/UnauthorizedTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/exception/auth/UnauthorizedTokenException.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.exception.auth
+
+class UnauthorizedTokenException : UnauthorizedException("Token is unauthorized.")

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -1,0 +1,71 @@
+package com.kroffle.knitting.controller.filter.auth
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+@Component
+class AuthorizationFilter : WebFilter {
+    @Autowired
+    lateinit var tokenHelper: TokenHelper
+
+    private fun resolveToken(headers: HttpHeaders): String? {
+        val authorizationHeaders = headers[HttpHeaders.AUTHORIZATION]
+        if (authorizationHeaders.isNullOrEmpty()) return null
+        val bearerToken = authorizationHeaders.first()
+        return if (bearerToken.startsWith(HEADER_PREFIX)) {
+            bearerToken.substring(HEADER_PREFIX.length)
+        } else null
+    }
+
+    private fun getAuthorization(headers: HttpHeaders): Mono<UUID> {
+        val token = resolveToken(headers)
+            ?: return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "Header is Empty"))
+        if (tokenHelper.validateToken(token)) {
+            return Mono.just(tokenHelper.getAuthorizedUserId(token)!!)
+        }
+        throw Error("invalid token")
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        val path = exchange.request.path.value()
+        if (path in PUBLIC_PATH) {
+            return chain.filter(exchange)
+        }
+        return getAuthorization(headers = exchange.request.headers).doOnError {
+            error ->
+            exchange.response.statusCode = HttpStatus.UNAUTHORIZED
+            val message = error.message
+            if (message != null) {
+                val byteMessages = message.toByteArray()
+                val buffer = exchange.response.bufferFactory().wrap(byteMessages)
+                exchange.response.writeWith(Flux.just(buffer))
+            }
+        }.then(
+            chain.filter(exchange)
+        )
+    }
+
+    interface TokenHelper {
+        fun getAuthorizedUserId(token: String): UUID?
+        fun validateToken(token: String): Boolean
+    }
+
+    companion object {
+        private const val HEADER_PREFIX = "Bearer "
+        private val PUBLIC_PATH = listOf(
+            "/ping",
+            "/favicon.ico",
+            "/auth/google/code",
+            "/auth/google/authorized",
+        )
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -20,7 +20,7 @@ import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_P
 @Component
 class AuthorizationFilter : WebFilter {
     @Autowired
-    lateinit var tokenHelper: TokenHelper
+    lateinit var tokenDecoder: TokenDecoder
 
     private fun resolveToken(headers: HttpHeaders): String? {
         val authorizationHeaders = headers[HttpHeaders.AUTHORIZATION]
@@ -35,7 +35,7 @@ class AuthorizationFilter : WebFilter {
         val token = resolveToken(headers)
             ?: return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "Header is Empty"))
         return try {
-            Mono.just(tokenHelper.getAuthorizedUserId(token))
+            Mono.just(tokenDecoder.getAuthorizedUserId(token))
         } catch (e: UnauthorizedException) {
             Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message))
         }
@@ -59,7 +59,7 @@ class AuthorizationFilter : WebFilter {
         )
     }
 
-    interface TokenHelper {
+    interface TokenDecoder {
         fun getAuthorizedUserId(token: String): UUID
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.controller.filter.auth
 
 import com.kroffle.knitting.controller.exception.auth.UnauthorizedException
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -18,10 +17,7 @@ import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUB
 import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_PATHS as PingRouterPublicPaths
 
 @Component
-class AuthorizationFilter : WebFilter {
-    @Autowired
-    lateinit var tokenDecoder: TokenDecoder
-
+class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
     private fun resolveToken(headers: HttpHeaders): String? {
         val authorizationHeaders = headers[HttpHeaders.AUTHORIZATION]
         if (authorizationHeaders.isNullOrEmpty()) return null

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -11,6 +11,10 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.UUID
+import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
+import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
+import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
+import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_PATHS as PingRouterPublicPaths
 
 @Component
 class AuthorizationFilter : WebFilter {
@@ -37,7 +41,7 @@ class AuthorizationFilter : WebFilter {
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
         val path = exchange.request.path.value()
-        if (path in PUBLIC_PATH) {
+        if (path in PUBLIC_PATHS) {
             return chain.filter(exchange)
         }
         return getAuthorization(headers = exchange.request.headers).doOnError {
@@ -61,11 +65,11 @@ class AuthorizationFilter : WebFilter {
 
     companion object {
         private const val HEADER_PREFIX = "Bearer "
-        private val PUBLIC_PATH = listOf(
-            "/ping",
-            "/favicon.ico",
-            "/auth/google/code",
-            "/auth/google/authorized",
-        )
+        private val PUBLIC_PATHS = (
+            LogInRouterPublicPaths +
+                DesignRouterPublicPaths +
+                DesignsRouterPublicPaths +
+                PingRouterPublicPaths
+            )
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CorsFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CorsFilter.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.infra.web
+package com.kroffle.knitting.controller.filter.cors
 
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/LogInRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/LogInRouter.kt
@@ -11,12 +11,22 @@ import org.springframework.web.reactive.function.server.router
 class LogInRouter(private val handler: GoogleLogInHandler) {
     @Bean
     fun logInRouterFunction() = RouterFunctions.nest(
-        RequestPredicates.path("/auth"),
+        RequestPredicates.path(ROOT_PATH),
         router {
             listOf(
-                POST("/google/code", handler::requestCode),
-                GET("/google/authorized", handler::authorized),
+                POST(REQUEST_CODE_PATH, handler::requestCode),
+                GET(AUTHORIZED_PATH, handler::authorized),
             )
         }
     )
+
+    companion object {
+        private const val ROOT_PATH = "/auth"
+        private const val REQUEST_CODE_PATH = "/google/code"
+        private const val AUTHORIZED_PATH = "/google/authorized"
+        val PUBLIC_PATHS = listOf(
+            "${ROOT_PATH}$REQUEST_CODE_PATH",
+            "${ROOT_PATH}$AUTHORIZED_PATH",
+        )
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
@@ -11,11 +11,17 @@ import org.springframework.web.reactive.function.server.router
 class DesignRouter(private val handler: DesignHandler) {
     @Bean
     fun designRouterFunction() = nest(
-        path("/design"),
+        path(ROOT_PATH),
         router {
             listOf(
-                POST("/", handler::createDesign),
+                POST(CREATE_DESIGN_PATH, handler::createDesign),
             )
         }
     )
+
+    companion object {
+        private const val ROOT_PATH = "/design"
+        private const val CREATE_DESIGN_PATH = "/"
+        val PUBLIC_PATHS = listOf<String>()
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -11,11 +11,19 @@ import org.springframework.web.reactive.function.server.router
 class DesignsRouter(private val handler: DesignHandler) {
     @Bean
     fun designsRouterFunction() = nest(
-        path("/designs"),
+        path(ROOT_PATH),
         router {
             listOf(
-                GET("/", handler::getAll),
+                GET(GET_ALL_PATH, handler::getAll),
             )
         }
     )
+
+    companion object {
+        private const val ROOT_PATH = "/designs"
+        private const val GET_ALL_PATH = "/"
+        val PUBLIC_PATHS = listOf(
+            "${ROOT_PATH}$GET_ALL_PATH",
+        )
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/ping/PingRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/ping/PingRouter.kt
@@ -11,9 +11,17 @@ import org.springframework.web.reactive.function.server.router
 class PingRouter(private val handler: PingHandler) {
     @Bean
     fun pingRouterFunction() = nest(
-        path("/ping"),
+        path(ROOT_PATH),
         router {
-            listOf(GET("/", handler::get))
+            listOf(GET(GET_PATH, handler::get))
         }
     )
+
+    companion object {
+        private const val ROOT_PATH = "/ping"
+        private const val GET_PATH = "/"
+        val PUBLIC_PATHS = listOf(
+            "${ROOT_PATH}$GET_PATH",
+        )
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.infra.configuration
 
-import com.kroffle.knitting.infra.jwt.TokenHelper
+import com.kroffle.knitting.infra.jwt.TokenDecoder
+import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOauthHelperImpl
 import com.kroffle.knitting.infra.properties.AuthProperties
 import com.kroffle.knitting.infra.properties.SelfProperties
@@ -23,7 +24,10 @@ class AppConfig {
     lateinit var authProperties: AuthProperties
 
     @Bean
-    fun tokenHelper() = TokenHelper(authProperties.jwtSecretKey)
+    fun tokenDecoder() = TokenDecoder(authProperties.jwtSecretKey)
+
+    @Bean
+    fun tokenPublisher() = TokenPublisher(authProperties.jwtSecretKey)
 
     @Bean
     fun designService(repository: DesignService.DesignRepository) = DesignService(repository)
@@ -31,6 +35,6 @@ class AppConfig {
     @Bean
     fun authService() = AuthService(
         GoogleOauthHelperImpl(selfProperties, webProperties.googleClientId),
-        tokenHelper()
+        tokenPublisher()
     )
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -23,11 +23,14 @@ class AppConfig {
     lateinit var authProperties: AuthProperties
 
     @Bean
+    fun tokenHelper() = TokenHelper(authProperties.jwtSecretKey)
+
+    @Bean
     fun designService(repository: DesignService.DesignRepository) = DesignService(repository)
 
     @Bean
     fun authService() = AuthService(
         GoogleOauthHelperImpl(selfProperties, webProperties.googleClientId),
-        TokenHelper(authProperties.jwtSecretKey)
+        tokenHelper()
     )
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenDecoder.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenDecoder.kt
@@ -9,23 +9,9 @@ import com.kroffle.knitting.controller.exception.auth.ExpiredTokenException
 import com.kroffle.knitting.controller.exception.auth.InvalidBodyTokenException
 import com.kroffle.knitting.controller.exception.auth.UnauthorizedTokenException
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
-import com.kroffle.knitting.pure.extensions.toDate
-import com.kroffle.knitting.usecase.auth.AuthService
-import java.time.LocalDateTime
 import java.util.UUID
 
-class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper, AuthorizationFilter.TokenHelper {
-    override fun publish(id: UUID): String {
-        val now = LocalDateTime.now()
-        val expiredAt = now.plusSeconds(EXPIRATION_TIME)
-
-        return JWT.create()
-            .withClaim("id", id.toString())
-            .withIssuedAt(now.toDate())
-            .withExpiresAt(expiredAt.toDate())
-            .sign(Algorithm.HMAC256(jwtSecretKey))
-    }
-
+class TokenDecoder(private val jwtSecretKey: String) : AuthorizationFilter.TokenDecoder {
     @Throws(ExpiredTokenException::class, UnauthorizedTokenException::class)
     private fun decodeToken(token: String): Map<String, Claim> {
         try {
@@ -45,9 +31,5 @@ class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper, A
         val claims = this.decodeToken(token)
         val id = claims["id"] ?: throw InvalidBodyTokenException()
         return UUID.fromString(id.asString())
-    }
-
-    companion object {
-        const val EXPIRATION_TIME = (60 * 60 * 24).toLong()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenHelper.kt
@@ -2,12 +2,16 @@ package com.kroffle.knitting.infra.jwt
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.JWTVerificationException
+import com.auth0.jwt.exceptions.TokenExpiredException
 import com.auth0.jwt.interfaces.Claim
-import com.kroffle.knitting.pure.extensions.toDate
+import com.kroffle.knitting.controller.exception.auth.ExpiredTokenException
+import com.kroffle.knitting.controller.exception.auth.InvalidBodyTokenException
+import com.kroffle.knitting.controller.exception.auth.UnauthorizedTokenException
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
+import com.kroffle.knitting.pure.extensions.toDate
 import com.kroffle.knitting.usecase.auth.AuthService
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.util.UUID
 
 class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper, AuthorizationFilter.TokenHelper {
@@ -22,29 +26,25 @@ class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper, A
             .sign(Algorithm.HMAC256(jwtSecretKey))
     }
 
+    @Throws(ExpiredTokenException::class, UnauthorizedTokenException::class)
     private fun decodeToken(token: String): Map<String, Claim> {
-        val jwt = JWT.require(Algorithm.HMAC256(jwtSecretKey))
-            .build()
-            .verify(token)
-        return jwt.claims
+        try {
+            val jwt = JWT.require(Algorithm.HMAC256(jwtSecretKey))
+                .build()
+                .verify(token)
+            return jwt.claims
+        } catch (e: TokenExpiredException) {
+            throw ExpiredTokenException()
+        } catch (e: JWTVerificationException) {
+            throw UnauthorizedTokenException()
+        }
     }
 
-    override fun getAuthorizedUserId(token: String): UUID? {
+    @Throws(InvalidBodyTokenException::class)
+    override fun getAuthorizedUserId(token: String): UUID {
         val claims = this.decodeToken(token)
-        val id = claims["id"] ?: return null
+        val id = claims["id"] ?: throw InvalidBodyTokenException()
         return UUID.fromString(id.asString())
-    }
-
-    override fun validateToken(token: String): Boolean {
-        val userId = getAuthorizedUserId(token)
-        val exp = getAuthorizationExp(token)
-        return userId != null && exp != null
-    }
-
-    fun getAuthorizationExp(token: String): LocalDateTime? {
-        val claims = this.decodeToken(token)
-        val exp = claims["exp"] ?: return null
-        return LocalDateTime.ofInstant(exp.asDate().toInstant(), ZoneId.systemDefault())
     }
 
     companion object {

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenHelper.kt
@@ -4,11 +4,13 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.Claim
 import com.kroffle.knitting.pure.extensions.toDate
+import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.usecase.auth.AuthService
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.UUID
 
-class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper {
+class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper, AuthorizationFilter.TokenHelper {
     override fun publish(id: UUID): String {
         val now = LocalDateTime.now()
         val expiredAt = now.plusSeconds(EXPIRATION_TIME)
@@ -20,11 +22,29 @@ class TokenHelper(private val jwtSecretKey: String) : AuthService.TokenHelper {
             .sign(Algorithm.HMAC256(jwtSecretKey))
     }
 
-    fun decodeToken(token: String): Map<String, Claim> {
+    private fun decodeToken(token: String): Map<String, Claim> {
         val jwt = JWT.require(Algorithm.HMAC256(jwtSecretKey))
             .build()
             .verify(token)
         return jwt.claims
+    }
+
+    override fun getAuthorizedUserId(token: String): UUID? {
+        val claims = this.decodeToken(token)
+        val id = claims["id"] ?: return null
+        return UUID.fromString(id.asString())
+    }
+
+    override fun validateToken(token: String): Boolean {
+        val userId = getAuthorizedUserId(token)
+        val exp = getAuthorizationExp(token)
+        return userId != null && exp != null
+    }
+
+    fun getAuthorizationExp(token: String): LocalDateTime? {
+        val claims = this.decodeToken(token)
+        val exp = claims["exp"] ?: return null
+        return LocalDateTime.ofInstant(exp.asDate().toInstant(), ZoneId.systemDefault())
     }
 
     companion object {

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenPublisher.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenPublisher.kt
@@ -1,0 +1,25 @@
+package com.kroffle.knitting.infra.jwt
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.kroffle.knitting.pure.extensions.toDate
+import com.kroffle.knitting.usecase.auth.AuthService
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TokenPublisher(private val jwtSecretKey: String) : AuthService.TokenPublisher {
+    override fun publish(id: UUID): String {
+        val now = LocalDateTime.now()
+        val expiredAt = now.plusSeconds(EXPIRATION_TIME)
+
+        return JWT.create()
+            .withClaim("id", id.toString())
+            .withIssuedAt(now.toDate())
+            .withExpiresAt(expiredAt.toDate())
+            .sign(Algorithm.HMAC256(jwtSecretKey))
+    }
+
+    companion object {
+        private const val EXPIRATION_TIME = (60 * 60 * 24).toLong()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -3,19 +3,19 @@ package com.kroffle.knitting.usecase.auth
 import java.net.URI
 import java.util.UUID
 
-class AuthService(private val oAuthHelper: GoogleOAuthHelper, private val tokenHelper: TokenHelper) {
+class AuthService(private val oAuthHelper: GoogleOAuthHelper, private val tokenPublisher: TokenPublisher) {
     fun getAuthorizationUri(): URI = oAuthHelper.getAuthorizationUri()
 
     fun authorize(): String {
         // TODO Implement
-        return tokenHelper.publish(UUID.randomUUID())
+        return tokenPublisher.publish(UUID.randomUUID())
     }
 
     interface GoogleOAuthHelper {
         fun getAuthorizationUri(): URI
     }
 
-    interface TokenHelper {
+    interface TokenPublisher {
         fun publish(id: UUID): String
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ web.jwt_secret_key=${KNITTING_JWT_SECRET_KEY}
 
 self.host=localhost:8080
 self.env=local
+
+server.error.whitelabel.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ self.host=localhost:8080
 self.env=local
 
 server.error.whitelabel.enabled=false
+server.error.include-message=always

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -12,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
-import java.time.LocalDateTime
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -76,7 +75,5 @@ class LoginRouterTest {
             .responseBody!!
         val regex = Regex("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
         assert(regex.matchEntire(tokenHelper.getAuthorizedUserId(result).toString()) != null)
-        val expiration = tokenHelper.getAuthorizationExp(result)!!
-        assert(expiration > LocalDateTime.now())
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -13,7 +13,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -76,12 +75,8 @@ class LoginRouterTest {
             .returnResult()
             .responseBody!!
         val regex = Regex("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
-        assert(regex.matchEntire(tokenHelper.decodeToken(result)["id"]!!.asString()) != null)
-        val today = LocalDateTime.now()
-        val expiration = LocalDateTime.ofInstant(
-            tokenHelper.decodeToken(result)["exp"]!!.asDate().toInstant(),
-            ZoneId.systemDefault()
-        )
-        assert(expiration > today)
+        assert(regex.matchEntire(tokenHelper.getAuthorizedUserId(result).toString()) != null)
+        val expiration = tokenHelper.getAuthorizationExp(result)!!
+        assert(expiration > LocalDateTime.now())
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -1,7 +1,8 @@
 package com.kroffle.knitting.controller.router.auth
 
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
-import com.kroffle.knitting.infra.jwt.TokenHelper
+import com.kroffle.knitting.infra.jwt.TokenDecoder
+import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOauthHelperImpl
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.usecase.auth.AuthService
@@ -16,11 +17,13 @@ import org.springframework.test.web.reactive.server.expectBody
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
 class LoginRouterTest {
-    lateinit var webClient: WebTestClient
+    private lateinit var webClient: WebTestClient
 
-    lateinit var selfProperties: SelfProperties
+    private lateinit var selfProperties: SelfProperties
 
-    lateinit var tokenHelper: TokenHelper
+    private lateinit var tokenPublisher: TokenPublisher
+
+    private lateinit var tokenDecoder: TokenDecoder
 
     @BeforeEach
     fun setUp() {
@@ -28,7 +31,7 @@ class LoginRouterTest {
         selfProperties.host = "localhost:2028"
         selfProperties.env = "test"
 
-        tokenHelper = TokenHelper("I'M SECRET KEY!")
+        tokenPublisher = TokenPublisher("I'M SECRET KEY!")
 
         val routerFunction = LogInRouter(
             GoogleLogInHandler(
@@ -37,7 +40,7 @@ class LoginRouterTest {
                         selfProperties,
                         "GOOGLE_CLIENT_ID"
                     ),
-                    tokenHelper,
+                    tokenPublisher,
                 )
             )
         ).logInRouterFunction()
@@ -74,6 +77,6 @@ class LoginRouterTest {
             .returnResult()
             .responseBody!!
         val regex = Regex("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
-        assert(regex.matchEntire(tokenHelper.getAuthorizedUserId(result).toString()) != null)
+        assert(regex.matchEntire(tokenDecoder.getAuthorizedUserId(result).toString()) != null)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -6,6 +6,7 @@ import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.infra.design.entity.DesignEntity
+import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.usecase.design.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
 import org.assertj.core.api.Assertions.assertThat
@@ -25,15 +26,18 @@ import reactor.core.publisher.Mono
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
 class DesignRouterTest {
-    @MockBean
-    lateinit var repo: DesignRepository
-
     private lateinit var webClient: WebTestClient
 
     private lateinit var design: Design
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    lateinit var repo: DesignRepository
+
+    @MockBean
+    lateinit var tokenDecoder: TokenDecoder
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.controller.router.design
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.enum.DesignType
@@ -26,8 +27,6 @@ import java.util.UUID
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
 class DesignsRouterTest {
-    @MockBean
-    lateinit var repo: DesignRepository
 
     private lateinit var webClient: WebTestClient
 
@@ -35,6 +34,12 @@ class DesignsRouterTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    lateinit var repo: DesignRepository
+
+    @MockBean
+    lateinit var tokenDecoder: AuthorizationFilter.TokenDecoder
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/ping/PingRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/ping/PingRouterTest.kt
@@ -1,10 +1,12 @@
 package com.kroffle.knitting.controller.router.ping
 
+import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.ping.PingHandler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
@@ -13,6 +15,9 @@ import org.springframework.test.web.reactive.server.expectBody
 @ExtendWith(SpringExtension::class)
 class PingRouterTest {
     lateinit var webClient: WebTestClient
+
+    @MockBean
+    lateinit var tokenDecoder: AuthorizationFilter.TokenDecoder
 
     @BeforeEach
     fun setUp() {


### PR DESCRIPTION

## PR 제안 사유

refreshToken의 경우에는 헤더에 인증토큰이 있는 유저만 접근할 수 있어야 하기 때문에,
router에서 private API의 경우에는 헤더에 유효한 토큰이 있는지 확인할 수 있도록 WebFilter를 구현합니다.

https://github.com/k-roffle/knitting-service/pull/48 를 베이스로 작업했고, https://github.com/k-roffle/knitting-service/pull/48/commits/c2fba6319c33b5aecc9c991ee8434916ec5f8bf8 부터 리뷰보면 됩니다!

resolves: #47

## 주요 변경 기록
- AuthorizationWebfilter 구현
- Webflux 설정 일부 수정
- CorsFilter 코드 위치 변경

## Code review

### Code review 에서 중점적으로 봐야하는 부분
- 나중에 유지보수 할 때 문제 생길만한 부분 없을지
- 에러 핸들링 부족한 부분이 없는지

## 기타 질문 및 특이 사항

AuthorizationWebfilter에 대한 테스트도 추가하려고 했는데, tokenDecoder만 mocking해줬는데도 동작을 안하더라구요 ㅠㅠ (webfilter 코드가 실행이 안됨..)
tokenDecoder는 mocking 처리하지 않으면 AuthorizationWebfilter가 만들어질 때 bean이 없어서 에러가 발생하는데..
component에서는 다른 bean을 주입해서 사용하면 안되는건가 싶은데 다른 방법이 뭐가 있는지 몰라서 삽질하다가 멈췄습니다 ㅇ<-<..