### PR TITLE
feat: 토큰 리프레시 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -50,6 +50,8 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
                 val buffer = exchange.response.bufferFactory().wrap(byteMessages)
                 exchange.response.writeWith(Flux.just(buffer))
             }
+        }.doOnSuccess {
+            exchange.attributes["userId"] = it
         }.then(
             chain.filter(exchange)
         )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -1,13 +1,16 @@
 package com.kroffle.knitting.controller.handler.auth
 
 import com.kroffle.knitting.usecase.auth.AuthService
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.ServerResponse.ok
 import org.springframework.web.reactive.function.server.ServerResponse.temporaryRedirect
+import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
+import java.util.UUID
 
 @Component
 class GoogleLogInHandler(private val authService: AuthService) {
@@ -19,5 +22,15 @@ class GoogleLogInHandler(private val authService: AuthService) {
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(authService.authorize())
+    }
+
+    fun refreshToken(req: ServerRequest): Mono<ServerResponse> {
+        val userId = req.attribute("userId")
+        if (userId.isEmpty) {
+            return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "userId is required"))
+        }
+        return ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(authService.refreshToken(userId.get() as UUID))
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -1,5 +1,7 @@
 package com.kroffle.knitting.controller.handler.auth
 
+import com.kroffle.knitting.controller.handler.auth.model.AuthorizedResponse
+import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -21,7 +23,7 @@ class GoogleLogInHandler(private val authService: AuthService) {
     fun authorized(req: ServerRequest): Mono<ServerResponse> {
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(mapOf("token" to authService.authorize()))
+            .bodyValue(AuthorizedResponse(authService.authorize()))
     }
 
     fun refreshToken(req: ServerRequest): Mono<ServerResponse> {
@@ -31,6 +33,6 @@ class GoogleLogInHandler(private val authService: AuthService) {
         }
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(mapOf("token" to authService.refreshToken(userId.get() as UUID)))
+            .bodyValue(RefreshTokenResponse(authService.refreshToken(userId.get() as UUID)))
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -21,7 +21,7 @@ class GoogleLogInHandler(private val authService: AuthService) {
     fun authorized(req: ServerRequest): Mono<ServerResponse> {
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(authService.authorize())
+            .bodyValue(mapOf("token" to authService.authorize()))
     }
 
     fun refreshToken(req: ServerRequest): Mono<ServerResponse> {
@@ -31,6 +31,6 @@ class GoogleLogInHandler(private val authService: AuthService) {
         }
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(authService.refreshToken(userId.get() as UUID))
+            .bodyValue(mapOf("token" to authService.refreshToken(userId.get() as UUID)))
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/AuthorizedResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/AuthorizedResponse.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.auth.model
+
+class AuthorizedResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/RefreshTokenResponse.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.auth.model
+
+class RefreshTokenResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/LogInRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/LogInRouter.kt
@@ -16,6 +16,7 @@ class LogInRouter(private val handler: GoogleLogInHandler) {
             listOf(
                 POST(REQUEST_CODE_PATH, handler::requestCode),
                 GET(AUTHORIZED_PATH, handler::authorized),
+                POST(REFRESH_TOKEN_PATH, handler::refreshToken),
             )
         }
     )
@@ -24,6 +25,7 @@ class LogInRouter(private val handler: GoogleLogInHandler) {
         private const val ROOT_PATH = "/auth"
         private const val REQUEST_CODE_PATH = "/google/code"
         private const val AUTHORIZED_PATH = "/google/authorized"
+        private const val REFRESH_TOKEN_PATH = "/refresh"
         val PUBLIC_PATHS = listOf(
             "${ROOT_PATH}$REQUEST_CODE_PATH",
             "${ROOT_PATH}$AUTHORIZED_PATH",

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -11,6 +11,10 @@ class AuthService(private val oAuthHelper: GoogleOAuthHelper, private val tokenP
         return tokenPublisher.publish(UUID.randomUUID())
     }
 
+    fun refreshToken(userId: UUID): String {
+        return tokenPublisher.publish(userId)
+    }
+
     interface GoogleOAuthHelper {
         fun getAuthorizationUri(): URI
     }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -2,6 +2,8 @@ package com.kroffle.knitting.controller.router.auth
 
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
+import com.kroffle.knitting.controller.handler.auth.model.AuthorizedResponse
+import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOauthHelperImpl
@@ -83,10 +85,10 @@ class LoginRouterTest {
             .uri("/auth/google/authorized")
             .exchange()
             .expectStatus().isOk
-            .expectBody<Map<String, String>>()
+            .expectBody<AuthorizedResponse>()
             .returnResult()
             .responseBody!!
-        tokenDecoder.getAuthorizedUserId(result["token"]!!)
+        tokenDecoder.getAuthorizedUserId(result.token)
     }
 
     @Test
@@ -99,9 +101,9 @@ class LoginRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<Map<String, String>>()
+            .expectBody<RefreshTokenResponse>()
             .returnResult()
             .responseBody!!
-        assert(TokenDecoder(secretKey).getAuthorizedUserId(result["token"]!!) == userId)
+        assert(TokenDecoder(secretKey).getAuthorizedUserId(result.token) == userId)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -83,10 +83,10 @@ class LoginRouterTest {
             .uri("/auth/google/authorized")
             .exchange()
             .expectStatus().isOk
-            .expectBody<String>()
+            .expectBody<Map<String, String>>()
             .returnResult()
             .responseBody!!
-        tokenDecoder.getAuthorizedUserId(result)
+        tokenDecoder.getAuthorizedUserId(result["token"]!!)
     }
 
     @Test
@@ -99,9 +99,9 @@ class LoginRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<String>()
+            .expectBody<Map<String, String>>()
             .returnResult()
             .responseBody!!
-        assert(TokenDecoder(secretKey).getAuthorizedUserId(result) == userId)
+        assert(TokenDecoder(secretKey).getAuthorizedUserId(result["token"]!!) == userId)
     }
 }


### PR DESCRIPTION

## PR 제안 사유
resolves: #49

토큰이 만료되기 전 토큰을 연장할 수 있는 API를 구현합니다.


## 주요 변경 기록
- 헤더 검사하는 webfilter에서 exchange 컨텍스트에 userId 들고 있을 수 있도록 수정
- 리프레스 요청 시 헤더 검사 완료 후 컨텍스트의 userId로 토큰 재생성
- 그리고 토큰 관련 API 포맷이 일반 text였는데 json으로 변경합니다!