### PR TITLE
feat: 구글에서 프로필 정보를 가져와 토큰을 발급하도록 수정합니다.

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -21,7 +21,11 @@ class GoogleLogInHandler(private val authService: AuthService) {
     }
 
     fun authorized(req: ServerRequest): Mono<ServerResponse> {
-        return authService.authorize().flatMap {
+        val code = req.queryParam("code")
+        if (code.isEmpty) {
+            return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "code is required"))
+        }
+        return authService.authorize(code.get()).flatMap {
             ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(AuthorizedResponse(it))

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -44,7 +44,11 @@ class AppConfig {
 
     @Bean
     fun authService(repository: AuthService.KnitterRepository) = AuthService(
-        GoogleOauthHelperImpl(selfProperties, webProperties.googleClientId),
+        GoogleOauthHelperImpl(
+            selfProperties,
+            webProperties.googleClientId,
+            webProperties.googleClientSecret,
+        ),
         tokenPublisher(),
         repository,
     )

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -6,7 +6,7 @@ import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.knitter.DBKnitterRepository
 import com.kroffle.knitting.infra.knitter.R2dbcKnitterRepository
-import com.kroffle.knitting.infra.oauth.GoogleOauthHelperImpl
+import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
 import com.kroffle.knitting.infra.properties.AuthProperties
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
@@ -44,7 +44,7 @@ class AppConfig {
 
     @Bean
     fun authService(repository: AuthService.KnitterRepository) = AuthService(
-        GoogleOauthHelperImpl(
+        GoogleOAuthHelperImpl(
             selfProperties,
             webProperties.googleClientId,
             webProperties.googleClientSecret,

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
@@ -16,7 +16,7 @@ class GoogleOAuthHelperImpl(
     private val selfProperties: SelfProperties,
     private val googleClientId: String,
     private val googleSecretKey: String,
-) : AuthService.GoogleOAuthHelper {
+) : AuthService.OAuthHelper {
 
     private fun getCallbackUri(): String {
         val scheme = when (selfProperties.env) {

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
@@ -12,7 +12,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
 import java.net.URI
 
-class GoogleOauthHelperImpl(
+class GoogleOAuthHelperImpl(
     private val selfProperties: SelfProperties,
     private val googleClientId: String,
     private val googleSecretKey: String,

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOauthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOauthHelperImpl.kt
@@ -30,7 +30,7 @@ class GoogleOauthHelperImpl(
                 .scheme("https")
                 .host("accounts.google.com")
                 .path("/o/oauth2/v2/auth")
-                .queryParam("scope", "profile")
+                .queryParam("scope", "profile+https://www.googleapis.com/auth/userinfo.email")
                 .queryParam("access_type", "offline")
                 .queryParam("include_granted_scopes", "true")
                 .queryParam("response_type", "code")

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOauthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOauthHelperImpl.kt
@@ -8,6 +8,7 @@ import java.net.URI
 class GoogleOauthHelperImpl(
     private val selfProperties: SelfProperties,
     private val googleClientId: String,
+    private val googleSecretKey: String,
 ) : AuthService.GoogleOAuthHelper {
 
     private fun getCallbackUri(): String {

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/AccessTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/AccessTokenResponse.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.infra.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AccessTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/ProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/ProfileResponse.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.infra.oauth.dto
+
+data class ProfileResponse(
+    val email: String,
+    val name: String,
+    val picture: String,
+)

--- a/src/main/kotlin/com/kroffle/knitting/infra/properties/WebApplicationProperties.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/properties/WebApplicationProperties.kt
@@ -10,4 +10,7 @@ class WebApplicationProperties {
 
     @Value("\${web.google.client_id}")
     lateinit var googleClientId: String
+
+    @Value("\${web.google.client_secret}")
+    lateinit var googleClientSecret: String
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -26,7 +26,7 @@ class AuthService(
         return tokenPublisher.publish(userId)
     }
 
-    interface GoogleOAuthHelper {
+    interface OAuthHelper {
         fun getAuthorizationUri(): URI
         fun getProfile(code: String): Mono<Profile>
     }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -12,7 +12,7 @@ class AuthService(
 ) {
     fun getAuthorizationUri(): URI = oAuthHelper.getAuthorizationUri()
 
-    fun authorize(): Mono<String> {
+    fun authorize(code: String): Mono<String> {
         // FIXME #45 구글로부터 이메일 정보를 받아오도록 변경해야 합니다.
         // 이미 존재하는 유저인 경우 프로필 정보를 업데이트해야 합니다.
         // 첫 로그인하는 유저인 경우 유저 정보를 생성해야 합니다.

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.usecase.auth
 
 import com.kroffle.knitting.domain.knitter.entity.Knitter
+import com.kroffle.knitting.usecase.auth.dto.Profile
 import reactor.core.publisher.Mono
 import java.net.URI
 import java.util.UUID
@@ -27,6 +28,7 @@ class AuthService(
 
     interface GoogleOAuthHelper {
         fun getAuthorizationUri(): URI
+        fun getProfile(code: String): Mono<Profile>
     }
 
     interface TokenPublisher {

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -7,18 +7,21 @@ import java.net.URI
 import java.util.UUID
 
 class AuthService(
-    private val oAuthHelper: GoogleOAuthHelper,
+    private val oAuthHelper: OAuthHelper,
     private val tokenPublisher: TokenPublisher,
     private val knitterRepository: KnitterRepository,
 ) {
     fun getAuthorizationUri(): URI = oAuthHelper.getAuthorizationUri()
 
     fun authorize(code: String): Mono<String> {
-        // FIXME #45 구글로부터 이메일 정보를 받아오도록 변경해야 합니다.
-        // 이미 존재하는 유저인 경우 프로필 정보를 업데이트해야 합니다.
+        // FIXME #45 이미 존재하는 유저인 경우 프로필 정보를 업데이트해야 합니다.
         // 첫 로그인하는 유저인 경우 유저 정보를 생성해야 합니다.
-        return knitterRepository.findByEmail("devuri404@gmail.com").flatMap {
-            Mono.just(tokenPublisher.publish(it.id!!))
+        return oAuthHelper.getProfile(code).flatMap {
+            profile ->
+            knitterRepository.findByEmail(profile.email).flatMap {
+                knitter ->
+                Mono.just(tokenPublisher.publish(knitter.id!!))
+            }
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/dto/Profile.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/dto/Profile.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.usecase.auth.dto
+
+data class Profile(
+    val email: String,
+    val name: String,
+    val profileImageUrl: String?,
+)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ db.password=
 
 web.origins=http://localhost:1909
 web.google.client_id=1036534335923-fcacoteap126dnkl0ttuouaguercstbi.apps.googleusercontent.com
+web.google.client_secret=${KNITTING_GOOGLE_CLIENT_SECRET}
 web.jwt_secret_key=${KNITTING_JWT_SECRET_KEY}
 
 self.host=localhost:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,6 @@ self.env=local
 
 server.error.whitelabel.enabled=false
 server.error.include-message=always
+
+spring.http.log-request-details=true
+logging.level.org.springframework.web.reactive.function.client.ExchangeFunctions=TRACE

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -101,7 +101,13 @@ class LoginRouterTest {
 
         val result = webClient
             .get()
-            .uri("/auth/google/authorized")
+            .uri {
+                uriBuilder ->
+                uriBuilder
+                    .path("/auth/google/authorized")
+                    .queryParam("code", "MOCK_CODE")
+                    .build()
+            }
             .exchange()
             .expectStatus().isOk
             .expectBody<AuthorizedResponse>()

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -71,7 +71,7 @@ class LoginRouterTest {
     @Test
     fun `로그인 요청 시 구글 인증 페이지로 리다이렉트 되어야 함`() {
         val expectedLocation = "https://accounts.google.com/o/oauth2/v2/auth" +
-            "?scope=profile" +
+            "?scope=profile+https://www.googleapis.com/auth/userinfo.email" +
             "&access_type=offline" +
             "&include_granted_scopes=true" +
             "&response_type=code" +

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -11,6 +11,7 @@ import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.usecase.auth.AuthService
 import com.kroffle.knitting.usecase.auth.KnitterRepository
+import com.kroffle.knitting.usecase.auth.dto.Profile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -31,6 +32,9 @@ class LoginRouterTest {
     private lateinit var selfProperties: SelfProperties
 
     private lateinit var tokenPublisher: TokenPublisher
+
+    @MockBean
+    private lateinit var mockOAuthHelper: AuthService.OAuthHelper
 
     @MockBean
     private lateinit var tokenDecoder: TokenDecoder
@@ -68,6 +72,18 @@ class LoginRouterTest {
             .build()
     }
 
+    private fun setWebClientWithMockOAuthHelper() {
+        val routerFunction = LogInRouter(
+            GoogleLogInHandler(
+                AuthService(mockOAuthHelper, tokenPublisher, repo),
+            )
+        ).logInRouterFunction()
+        webClient = WebTestClient
+            .bindToRouterFunction(routerFunction)
+            .webFilter<WebTestClient.RouterFunctionSpec>(AuthorizationFilter(tokenDecoder))
+            .build()
+    }
+
     @Test
     fun `로그인 요청 시 구글 인증 페이지로 리다이렉트 되어야 함`() {
         val expectedLocation = "https://accounts.google.com/o/oauth2/v2/auth" +
@@ -89,14 +105,26 @@ class LoginRouterTest {
 
     @Test
     fun `구글 인증 후 access token 을 발급 받을 수 있어야 함`() {
-        given(repo.findByEmail("devuri404@gmail.com")).willReturn(
+        setWebClientWithMockOAuthHelper()
+
+        given(repo.findByEmail("mock@email.com")).willReturn(
             Mono.just(
                 KnitterEntity(
                     id = UUID.randomUUID(),
-                    email = "devuri404@gmail.com",
+                    email = "mock@email.com",
                     name = null,
                     profileImageUrl = null,
                 ).toKnitter(),
+            )
+        )
+
+        given(mockOAuthHelper.getProfile("MOCK_CODE")).willReturn(
+            Mono.just(
+                Profile(
+                    email = "mock@email.com",
+                    name = "John Doe",
+                    profileImageUrl = null
+                )
             )
         )
 

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -54,7 +54,8 @@ class LoginRouterTest {
                 AuthService(
                     GoogleOauthHelperImpl(
                         selfProperties,
-                        "GOOGLE_CLIENT_ID"
+                        "GOOGLE_CLIENT_ID",
+                        "GOOGLE_SECRET_KEY",
                     ),
                     tokenPublisher,
                     repo,

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -7,7 +7,7 @@ import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.knitter.entity.KnitterEntity
-import com.kroffle.knitting.infra.oauth.GoogleOauthHelperImpl
+import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.usecase.auth.AuthService
 import com.kroffle.knitting.usecase.auth.KnitterRepository
@@ -52,7 +52,7 @@ class LoginRouterTest {
         val routerFunction = LogInRouter(
             GoogleLogInHandler(
                 AuthService(
-                    GoogleOauthHelperImpl(
+                    GoogleOAuthHelperImpl(
                         selfProperties,
                         "GOOGLE_CLIENT_ID",
                         "GOOGLE_SECRET_KEY",


### PR DESCRIPTION

## PR 제안 사유


resolves #45 

구글 로그인 완료 후 구글에서 프로필 정보를 가져올 수 있도록 합니다.
해당 PR에서는 구글 email로 계정을 조회하여 토큰을 발급받을 수 있도록 하였습니다.

남은 작업은 email을 통해 존재하던 계정이라면 프로필 정보를 업데이트, 존재하지 않는다면 신규 생성 후 토큰을 발급 할 수 있도록 해야 합니다.



## 주요 변경 기록
- code 통해서 google access token 발급받도록 수정
- 발급받은 access token 통해서 프로필 정보 조회할 수 있도록 수정
- access token scope에 email 추가
- 조회한 프로필 통해서 유저 조회하고 토큰 생성하도록 수정
- 이전 리뷰 반영 https://github.com/k-roffle/knitting-service/pull/53#discussion_r659264851
- GoogleOAuthHelper 이름 변경
  - Service 에서는 google인지 facebook인지 구체적인 내용에 대해 알 필요 없기 때문에 제외해주었어요.
