### PR TITLE
feat: 구글 로그인시 프로필 정보 저장하도록 수정

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/infra/knitter/R2dbcKnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/knitter/R2dbcKnitterRepository.kt
@@ -10,6 +10,10 @@ class R2dbcKnitterRepository(private val dbDesignRepository: DBKnitterRepository
         .save(user.toKnitterEntity())
         .map { it.toKnitter() }
 
+    override fun update(user: Knitter): Mono<Knitter> = dbDesignRepository
+        .save(user.toKnitterEntity())
+        .map { it.toKnitter() }
+
     override fun findByEmail(email: String): Mono<Knitter> = dbDesignRepository
         .findFirstByEmail(email)
         .map { it.toKnitter() }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.usecase.auth
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.usecase.auth.dto.Profile
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
 import java.net.URI
 import java.util.UUID
 
@@ -29,7 +30,19 @@ class AuthService(
                             createdAt = knitter.createdAt,
                         )
                     )
-                }.flatMap {
+                }
+                .switchIfEmpty {
+                    knitterRepository.create(
+                        Knitter(
+                            id = null,
+                            email = profile.email,
+                            name = profile.name,
+                            profileImageUrl = profile.profileImageUrl,
+                            createdAt = null,
+                        )
+                    )
+                }
+                .flatMap {
                     Mono.just(tokenPublisher.publish(it.id!!))
                 }
         }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -14,14 +14,24 @@ class AuthService(
     fun getAuthorizationUri(): URI = oAuthHelper.getAuthorizationUri()
 
     fun authorize(code: String): Mono<String> {
-        // FIXME #45 이미 존재하는 유저인 경우 프로필 정보를 업데이트해야 합니다.
-        // 첫 로그인하는 유저인 경우 유저 정보를 생성해야 합니다.
         return oAuthHelper.getProfile(code).flatMap {
             profile ->
-            knitterRepository.findByEmail(profile.email).flatMap {
-                knitter ->
-                Mono.just(tokenPublisher.publish(knitter.id!!))
-            }
+            knitterRepository
+                .findByEmail(profile.email)
+                .flatMap {
+                    knitter ->
+                    knitterRepository.update(
+                        Knitter(
+                            id = knitter.id,
+                            email = knitter.email,
+                            name = profile.name,
+                            profileImageUrl = profile.profileImageUrl,
+                            createdAt = knitter.createdAt,
+                        )
+                    )
+                }.flatMap {
+                    Mono.just(tokenPublisher.publish(it.id!!))
+                }
         }
     }
 
@@ -40,6 +50,7 @@ class AuthService(
 
     interface KnitterRepository {
         fun create(user: Knitter): Mono<Knitter>
+        fun update(user: Knitter): Mono<Knitter>
         fun findByEmail(email: String): Mono<Knitter>
     }
 }

--- a/src/main/resources/db/migration/V6__add_default_value.sql
+++ b/src/main/resources/db/migration/V6__add_default_value.sql
@@ -1,0 +1,1 @@
+ALTER TABLE knitter ALTER COLUMN id SET DEFAULT uuid_generate_v4();

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -4,6 +4,7 @@ import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
 import com.kroffle.knitting.controller.handler.auth.model.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
+import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.knitter.entity.KnitterEntity
@@ -16,12 +17,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.verify
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Mono
+import java.time.LocalDateTime
 import java.util.UUID
 
 @WebFluxTest
@@ -104,19 +109,15 @@ class LoginRouterTest {
     }
 
     @Test
-    fun `구글 인증 후 access token 을 발급 받을 수 있어야 함`() {
+    fun `이미 가입한 유저인 경우 프로필 정보를 업데이트 한 후 access token 을 발급 받을 수 있어야 함`() {
         setWebClientWithMockOAuthHelper()
-
-        given(repo.findByEmail("mock@email.com")).willReturn(
-            Mono.just(
-                KnitterEntity(
-                    id = UUID.randomUUID(),
-                    email = "mock@email.com",
-                    name = null,
-                    profileImageUrl = null,
-                ).toKnitter(),
-            )
-        )
+        val targetKnitter = KnitterEntity(
+            id = UUID.randomUUID(),
+            email = "mock@email.com",
+            name = null,
+            profileImageUrl = null,
+            createdAt = LocalDateTime.now(),
+        ).toKnitter()
 
         given(mockOAuthHelper.getProfile("MOCK_CODE")).willReturn(
             Mono.just(
@@ -127,6 +128,23 @@ class LoginRouterTest {
                 )
             )
         )
+
+        given(repo.findByEmail("mock@email.com")).willReturn(
+            Mono.just(targetKnitter)
+        )
+
+        given(repo.update(any()))
+            .willReturn(
+                Mono.just(
+                    Knitter(
+                        id = targetKnitter.id,
+                        email = "mock@email.com",
+                        name = "John Doe",
+                        profileImageUrl = null,
+                        createdAt = targetKnitter.createdAt,
+                    ),
+                )
+            )
 
         val result = webClient
             .get()
@@ -142,7 +160,19 @@ class LoginRouterTest {
             .expectBody<AuthorizedResponse>()
             .returnResult()
             .responseBody!!
-        tokenDecoder.getAuthorizedUserId(result.token)
+        assert(tokenDecoder.getAuthorizedUserId(result.token) == targetKnitter.id)
+
+        verify(repo).update(
+            argThat {
+                param ->
+                assert(param.id == targetKnitter.id)
+                assert(param.email == targetKnitter.email)
+                assert(param.name == "John Doe")
+                assert(param.profileImageUrl == null)
+                assert(param.createdAt == targetKnitter.createdAt)
+                true
+            }
+        )
     }
 
     @Test


### PR DESCRIPTION

## PR 제안 사유

resolves: #55 

구글 로그인시 토큰을 리턴하기 전에 구글로부터 받아온 프로필 정보를 저장합니다.
이미 가입된 유저인 경우 데이터를 업데이트하고, 새로운 유저인 경우 데이터를 새로 생성합니다.

https://github.com/k-roffle/knitting-service/pull/56 를 기반으로 작업했습니다!

[feat: update knitter before publishing token](https://github.com/k-roffle/knitting-service/commit/7c1c73b7871fdb1d98d52ca96691b1139bf49231)부터 리뷰보면 돼요!

## 주요 변경 기록
- 이미 가입된 유저인 경우 업데이트 하도록
- 가입된 이력이 없는 유저인 경우 생성하도록
- knitter 테이블의 id 컬럼에 기본값 정의
