### PR TITLE
fix: 오타 수정 

### DIFF
--- a/src/main/resources/db/migration/V1__Initial.sql
+++ b/src/main/resources/db/migration/V1__Initial.sql
@@ -13,7 +13,7 @@ CREATE TABLE knitter (
 
 CREATE TABLE design (
     id BIGSERIAL NOT NULL,
-    knitterId BIGSERIAL NOT NULL REFERENCES knitter(id),
+    knitter_id BIGSERIAL NOT NULL REFERENCES knitter(id),
     name VARCHAR NOT NULL,
     design_type design_type NOT NULL,
     pattern_type pattern_type NOT NULL,


### PR DESCRIPTION

## PR 제안 사유
design 테이블에 추가한 knitter_id 컬럼의 오타를 수정합니다.
tmi) psql에서는 대소문자를 구분하지 않기 때문에 카멜케이스를 사용하면 knitterid가 됩니다 ㅎㅎ
