### PR TITLE
feat: 판매 내역 요약 mock API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.controller.handler.design
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.controller.handler.design.dto.MyDesignsResponse
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
+import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
@@ -109,6 +110,17 @@ class DesignHandler(private val service: DesignService) {
                         MyDesignsResponse(designs = it)
                     )
             }
+    }
+
+    fun getMySalesSummary(req: ServerRequest): Mono<ServerResponse> {
+        return ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                SalesSummaryResponse(
+                    numberOfDesignsOnSales = 1,
+                    numberOfDesignsSold = 2,
+                )
+            )
     }
 
     private fun validate(design: NewDesignRequest) {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.controller.handler.design.dto
+
+data class SalesSummaryResponse(
+    val numberOfDesignsOnSales: Int,
+    val numberOfDesignsSold: Int,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -15,6 +15,7 @@ class DesignsRouter(private val handler: DesignHandler) {
         router {
             listOf(
                 GET(GET_MY_DESIGNS_PATH, handler::getMyDesigns),
+                GET(GET_MY_SALES_SUMMARY_PATH, handler::getMySalesSummary),
             )
         }
     )
@@ -22,6 +23,7 @@ class DesignsRouter(private val handler: DesignHandler) {
     companion object {
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/my"
+        private const val GET_MY_SALES_SUMMARY_PATH = "/sales-summary/my"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }


### PR DESCRIPTION
## PR 제안 사유

판매 내역 요약 mock API를 구현합니다.

resolves: #65

## 요청

### request example
```
GET /designs/sales-summary/my http/1.1

Authorization: Bearer <Token>
```

### response example
```json
{
    "number_of_designs_on_sales": 1,
    "number_of_designs_sold": 2
}
```