### PR TITLE
feat: 내 프로필 조회할 수 있는 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -11,6 +11,7 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
+import com.kroffle.knitting.controller.router.auth.ProfileRouter.Companion.PUBLIC_PATHS as ProfileRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
 import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_PATHS as PingRouterPublicPaths
@@ -64,6 +65,7 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
         private const val HEADER_PREFIX = "Bearer "
         private val PUBLIC_PATHS = (
             LogInRouterPublicPaths +
+                ProfileRouterPublicPaths +
                 DesignRouterPublicPaths +
                 DesignsRouterPublicPaths +
                 PingRouterPublicPaths

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.controller.handler.auth
 
-import com.kroffle.knitting.controller.handler.auth.model.AuthorizedResponse
-import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
+import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
+import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
@@ -1,0 +1,36 @@
+package com.kroffle.knitting.controller.handler.auth
+
+import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
+import com.kroffle.knitting.usecase.auth.AuthService
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.ServerResponse.ok
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.Mono
+
+@Component
+class ProfileHandler(private val authService: AuthService) {
+    fun getMyProfile(req: ServerRequest): Mono<ServerResponse> {
+        val userId = req.attribute("userId")
+        if (userId.isEmpty) {
+            return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "userId is required"))
+        }
+        return authService
+            .getKnitter(userId.get() as Long)
+            .flatMap {
+                knitter ->
+                ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(
+                        MyProfileResponse(
+                            email = knitter.email,
+                            name = knitter.name,
+                            profileImageUrl = knitter.profileImageUrl,
+                        )
+                    )
+            }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.auth.dto
+
+class AuthorizedResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.controller.handler.auth.dto
+
+data class MyProfileResponse(
+    val email: String,
+    val profileImageUrl: String?,
+    val name: String?,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
@@ -1,7 +1,10 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class MyProfileResponse(
     val email: String,
+    @JsonProperty("profile_image_url")
     val profileImageUrl: String?,
     val name: String?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.auth.dto
+
+class RefreshTokenResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/AuthorizedResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/AuthorizedResponse.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.controller.handler.auth.model
-
-class AuthorizedResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/model/RefreshTokenResponse.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.controller.handler.auth.model
-
-class RefreshTokenResponse(val token: String)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
@@ -1,9 +1,12 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class MyDesign(
     val id: Long,
     val name: String,
     val yarn: String,
+    @JsonProperty("thumbnail_image_url")
     val thumbnailImageUrl: String?,
     val tags: List<String>,
 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
@@ -1,6 +1,10 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class SalesSummaryResponse(
+    @JsonProperty("number_of_designs_on_sales")
     val numberOfDesignsOnSales: Int,
+    @JsonProperty("number_of_designs_sold")
     val numberOfDesignsSold: Int,
 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouter.kt
@@ -1,0 +1,27 @@
+package com.kroffle.knitting.controller.router.auth
+
+import com.kroffle.knitting.controller.handler.auth.ProfileHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RequestPredicates
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.router
+
+@Configuration
+class ProfileRouter(private val handler: ProfileHandler) {
+    @Bean
+    fun profileRouterFunction() = RouterFunctions.nest(
+        RequestPredicates.path(ROOT_PATH),
+        router {
+            listOf(
+                GET(GET_MY_PROFILE_PATH, handler::getMyProfile),
+            )
+        }
+    )
+
+    companion object {
+        private const val ROOT_PATH = "/profile"
+        private const val GET_MY_PROFILE_PATH = "/"
+        val PUBLIC_PATHS: List<String> = listOf()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouter.kt
@@ -14,14 +14,13 @@ class ProfileRouter(private val handler: ProfileHandler) {
         RequestPredicates.path(ROOT_PATH),
         router {
             listOf(
-                GET(GET_MY_PROFILE_PATH, handler::getMyProfile),
+                GET(handler::getMyProfile),
             )
         }
     )
 
     companion object {
         private const val ROOT_PATH = "/profile"
-        private const val GET_MY_PROFILE_PATH = "/"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/knitter/R2dbcKnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/knitter/R2dbcKnitterRepository.kt
@@ -17,4 +17,8 @@ class R2dbcKnitterRepository(private val dbDesignRepository: DBKnitterRepository
     override fun findByEmail(email: String): Mono<Knitter> = dbDesignRepository
         .findFirstByEmail(email)
         .map { it.toKnitter() }
+
+    override fun findById(id: Long): Mono<Knitter> = dbDesignRepository
+        .findById(id)
+        .map { it.toKnitter() }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -51,6 +51,9 @@ class AuthService(
         return tokenPublisher.publish(userId)
     }
 
+    fun getKnitter(knitterId: Long): Mono<Knitter> =
+        knitterRepository.findById(knitterId)
+
     interface OAuthHelper {
         fun getAuthorizationUri(): URI
         fun getProfile(code: String): Mono<Profile>
@@ -64,5 +67,6 @@ class AuthService(
         fun create(user: Knitter): Mono<Knitter>
         fun update(user: Knitter): Mono<Knitter>
         fun findByEmail(email: String): Mono<Knitter>
+        fun findById(id: Long): Mono<Knitter>
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -2,8 +2,8 @@ package com.kroffle.knitting.controller.router.auth
 
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
-import com.kroffle.knitting.controller.handler.auth.model.AuthorizedResponse
-import com.kroffle.knitting.controller.handler.auth.model.RefreshTokenResponse
+import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
+import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
@@ -1,0 +1,114 @@
+package com.kroffle.knitting.controller.router.auth
+
+import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
+import com.kroffle.knitting.controller.handler.auth.ProfileHandler
+import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
+import com.kroffle.knitting.infra.jwt.TokenDecoder
+import com.kroffle.knitting.infra.jwt.TokenPublisher
+import com.kroffle.knitting.infra.knitter.entity.KnitterEntity
+import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
+import com.kroffle.knitting.infra.oauth.dto.ClientInfo
+import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
+import com.kroffle.knitting.infra.properties.WebApplicationProperties
+import com.kroffle.knitting.usecase.auth.AuthService
+import com.kroffle.knitting.usecase.auth.KnitterRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import reactor.core.publisher.Mono
+
+@WebFluxTest
+@ExtendWith(SpringExtension::class)
+class ProfileRouterTest {
+    private lateinit var webClient: WebTestClient
+
+    private lateinit var tokenPublisher: TokenPublisher
+
+    private lateinit var token: String
+
+    @MockBean
+    private lateinit var mockOAuthHelper: AuthService.OAuthHelper
+
+    @MockBean
+    private lateinit var tokenDecoder: TokenDecoder
+
+    @MockBean
+    lateinit var repo: KnitterRepository
+
+    @MockBean
+    private lateinit var webProperties: WebApplicationProperties
+
+    private val secretKey = "I'M SECRET KEY!"
+    private val userId: Long = 1
+
+    @BeforeEach
+    fun setUp() {
+        tokenPublisher = TokenPublisher(secretKey)
+        tokenDecoder = TokenDecoder(secretKey)
+
+        token = tokenPublisher.publish(userId)
+
+        val routerFunction = ProfileRouter(
+            ProfileHandler(
+                AuthService(
+                    GoogleOAuthHelperImpl(
+                        ClientInfo(
+                            "http",
+                            "localhost:2028"
+                        ),
+                        GoogleOAuthConfig(
+                            "GOOGLE_CLIENT_ID",
+                            "GOOGLE_SECRET_KEY",
+                        ),
+                    ),
+                    tokenPublisher,
+                    repo,
+                ),
+            )
+        ).profileRouterFunction()
+        webClient = WebTestClient
+            .bindToRouterFunction(routerFunction)
+            .webFilter<WebTestClient.RouterFunctionSpec>(AuthorizationFilter(tokenDecoder))
+            .build()
+    }
+
+    @Test
+    fun `내 프로필을 조회할 수 있어야 함`() {
+        given(repo.findById(userId))
+            .willReturn(
+                Mono.just(
+                    KnitterEntity(
+                        id = 1,
+                        name = "홍길동",
+                        email = "test@test.com",
+                        profileImageUrl = null,
+                    ).toKnitter()
+                )
+            )
+
+        val result = webClient
+            .get()
+            .uri("/profile/")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<MyProfileResponse>()
+            .returnResult()
+            .responseBody!!
+
+        assertThat(result).isEqualTo(
+            MyProfileResponse(
+                name = "홍길동",
+                email = "test@test.com",
+                profileImageUrl = null,
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
@@ -95,7 +95,7 @@ class ProfileRouterTest {
 
         val result = webClient
             .get()
-            .uri("/profile/")
+            .uri("/profile")
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk


### PR DESCRIPTION
## PR 제안 사유
내 프로필 조회할 수 있는 API를 구현합니다.

resolves: #72

## 주요 변경 기록
- 내프로필 조회할 수 있도록 API 구현
- json request, response 중 snake_case 아닌 부분 수정

## 요청 / 응답

### request example

```
GET /profile/ HTTP/1.1

Authorization: Bearer <Token>
```

### response example

```json
{
    "email": "devuri404@gmail.com",
    "profile_image_url": null,
    "name": null
}
```
