### PR TITLE
fix: ping API의 content type 수정

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/ping/PingHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/ping/PingHandler.kt
@@ -10,6 +10,6 @@ import reactor.core.publisher.Mono
 @Component
 class PingHandler {
     fun get(req: ServerRequest): Mono<ServerResponse> = ok()
-        .contentType(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.TEXT_PLAIN)
         .bodyValue("pong")
 }


### PR DESCRIPTION

## PR 제안 사유

- ping API 의 응답은 "pong"으로 json이 아닌 일반 text 입니다.
- json content type으로 설정하는 경우 리턴되는 값이 json이 아니라 에러가 발생하므로 text plain 으로 지정해줍니다.

## 주요 변경 기록

ping 응답시 content type 수정 
