### PR TITLE
feat: 커서 기반 페이지네이션 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,9 @@
 
 ## Environment
 
-- Project Owner 에게 secret_env.sh 파일을 요청하여 받습니다.
-  - 전달받은 파일은 프로젝트 루트에 두고 관리합니다.
-- 실행 전 secret_env.sh를 실행하여 환경변수를 설정해줍니다.
-- IDE를 이용하여 실행하는 경우 해당 파일의 환경설정을 IDE에 별도로 설정해줍니다.
-  - IntelliJ 기준 아래 방법으로 설정할 수 있습니다.
-    - [Run] -> [Edit Configurations] -> [Environment variables]
+- `src/main/resources/application.properties` 를 복사하여 application-local.properties 파일을 만듭니다.
+- 해당 파일에 local 환경에 맞게 변수를 설정합니다.
+- `-Dspring.profiles.active=local` 옵션을 이용하여 local 환경으로 설정하고 실행합니다.
 
 ## Format
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.controller.handler.auth
 import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
 import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -31,12 +32,9 @@ class GoogleLogInHandler(private val authService: AuthService) {
     }
 
     fun refreshToken(req: ServerRequest): Mono<ServerResponse> {
-        val userId = req.attribute("userId")
-        if (userId.isEmpty) {
-            throw Unauthorized("userId is required")
-        }
+        val knitterId = AuthHelper.getAuthenticatedId(req)
         return ok()
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(RefreshTokenResponse(authService.refreshToken(userId.get() as Long)))
+            .bodyValue(RefreshTokenResponse(authService.refreshToken(knitterId)))
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
@@ -1,14 +1,12 @@
 package com.kroffle.knitting.controller.handler.auth
 
 import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
-import com.kroffle.knitting.controller.handler.exception.Unauthorized
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.usecase.auth.AuthService
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.ServerResponse.ok
 import reactor.core.publisher.Mono
 
 @Component
@@ -17,17 +15,16 @@ class ProfileHandler(private val authService: AuthService) {
         val knitterId = AuthHelper.getAuthenticatedId(req)
         return authService
             .getKnitter(knitterId)
-            .flatMap {
+            .map {
                 knitter ->
-                ok()
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(
-                        MyProfileResponse(
-                            email = knitter.email,
-                            name = knitter.name,
-                            profileImageUrl = knitter.profileImageUrl,
-                        )
-                    )
+                MyProfileResponse(
+                    email = knitter.email,
+                    name = knitter.name,
+                    profileImageUrl = knitter.profileImageUrl,
+                )
+            }
+            .flatMap {
+                ResponseHelper.makeJsonResponse(it)
             }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/ProfileHandler.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.handler.auth
 
 import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
 import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -13,12 +14,9 @@ import reactor.core.publisher.Mono
 @Component
 class ProfileHandler(private val authService: AuthService) {
     fun getMyProfile(req: ServerRequest): Mono<ServerResponse> {
-        val userId = req.attribute("userId")
-        if (userId.isEmpty) {
-            throw Unauthorized("userId is required")
-        }
+        val knitterId = AuthHelper.getAuthenticatedId(req)
         return authService
-            .getKnitter(userId.get() as Long)
+            .getKnitter(knitterId)
             .flatMap {
                 knitter ->
                 ok()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
@@ -1,3 +1,5 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
-class AuthorizedResponse(val token: String)
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+
+class AuthorizedResponse(val token: String) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
@@ -1,10 +1,11 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
 
 data class MyProfileResponse(
     val email: String,
     @JsonProperty("profile_image_url")
     val profileImageUrl: String?,
     val name: String?,
-)
+) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
@@ -1,3 +1,5 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
-class RefreshTokenResponse(val token: String)
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+
+class RefreshTokenResponse(val token: String) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -6,6 +6,7 @@ import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
 import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
 import com.kroffle.knitting.controller.handler.exception.BadRequest
 import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
@@ -13,6 +14,9 @@ import com.kroffle.knitting.domain.design.value.Money
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.validation.BeanPropertyBindingResult
@@ -86,12 +90,20 @@ class DesignHandler(private val service: DesignService) {
     }
 
     fun getMyDesigns(req: ServerRequest): Mono<ServerResponse> {
+        // TODO 5: last_cursor 내려주기
+        val paging = PaginationHelper.getPagingFromRequest(req)
         val userId = req.attribute("userId")
         if (userId.isEmpty) {
             throw Unauthorized("userId is required")
         }
         return service
-            .getMyDesign(userId.get() as Long)
+            .getMyDesign(
+                MyDesignFilter(
+                    userId.get() as Long,
+                    paging,
+                    Sort("id", SortDirection.DESC),
+                )
+            )
             .map {
                 design ->
                 MyDesign(

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -1,13 +1,13 @@
 package com.kroffle.knitting.controller.handler.design
 
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
-import com.kroffle.knitting.controller.handler.design.dto.MyDesignsResponse
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
+import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
 import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
 import com.kroffle.knitting.controller.handler.exception.BadRequest
-import com.kroffle.knitting.controller.handler.exception.Unauthorized
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
+import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
@@ -18,13 +18,11 @@ import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.Errors
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.ServerResponse.ok
 import org.springframework.web.server.ServerWebInputException
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList
@@ -80,15 +78,14 @@ class DesignHandler(private val service: DesignService) {
                     )
                 )
             }
-            .flatMap {
-                ok()
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(it)
+            .map {
+                NewDesignResponse(id = it.id!!)
+            }.flatMap {
+                ResponseHelper.makeJsonResponse(it)
             }
     }
 
     fun getMyDesigns(req: ServerRequest): Mono<ServerResponse> {
-        // TODO 5: last_cursor 내려주기
         val paging = PaginationHelper.getPagingFromRequest(req)
         val knitterId = AuthHelper.getAuthenticatedId(req)
         return service
@@ -111,18 +108,13 @@ class DesignHandler(private val service: DesignService) {
             }
             .collect(toList())
             .flatMap {
-                ok()
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(
-                        MyDesignsResponse(designs = it)
-                    )
+                ResponseHelper.makeJsonResponse(it)
             }
     }
 
     fun getMySalesSummary(req: ServerRequest): Mono<ServerResponse> {
-        return ok()
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(
+        return ResponseHelper
+            .makeJsonResponse(
                 SalesSummaryResponse(
                     numberOfDesignsOnSales = 1,
                     numberOfDesignsSold = 2,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
@@ -1,12 +1,15 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemData
 
-data class MyDesign(
+class MyDesign(
     val id: Long,
     val name: String,
     val yarn: String,
     @JsonProperty("thumbnail_image_url")
     val thumbnailImageUrl: String?,
     val tags: List<String>,
-)
+) : ListItemData {
+    override fun getCursor(): String = id.toString()
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesignsResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesignsResponse.kt
@@ -1,5 +1,0 @@
-package com.kroffle.knitting.controller.handler.design.dto
-
-data class MyDesignsResponse(
-    val designs: List<MyDesign>,
-)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignResponse.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.controller.handler.design.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+
+data class NewDesignResponse(
+    val id: Long,
+) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
@@ -1,10 +1,11 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
 
 data class SalesSummaryResponse(
     @JsonProperty("number_of_designs_on_sales")
     val numberOfDesignsOnSales: Int,
     @JsonProperty("number_of_designs_sold")
     val numberOfDesignsSold: Int,
-)
+) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
@@ -1,0 +1,16 @@
+package com.kroffle.knitting.controller.handler.helper.auth
+
+import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import org.springframework.web.reactive.function.server.ServerRequest
+
+class AuthHelper {
+    companion object {
+        fun getAuthenticatedId(request: ServerRequest): Long {
+            val userId = request.attribute("userId")
+            if (userId.isEmpty) {
+                throw Unauthorized("userId is required")
+            }
+            return userId.get() as Long
+        }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.pagination
 
+import com.kroffle.knitting.controller.handler.exception.BadRequest
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import org.springframework.web.reactive.function.server.ServerRequest
 
@@ -22,7 +23,11 @@ class PaginationHelper {
         }
 
         fun getPagingFromRequest(req: ServerRequest): Paging {
-            return Paging(after = getAfter(req), count = getCount(req))
+            try {
+                return Paging(after = getAfter(req), count = getCount(req))
+            } catch (e: IllegalArgumentException) {
+                throw BadRequest(e.message ?: "Invalid paging parameter")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -1,0 +1,28 @@
+package com.kroffle.knitting.controller.handler.helper.pagination
+
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import org.springframework.web.reactive.function.server.ServerRequest
+
+class PaginationHelper {
+    companion object {
+        private fun getValue(request: ServerRequest, key: String): String? {
+            val value = request.queryParam(key)
+            return if (value.isEmpty) null
+            else value.get()
+        }
+
+        private fun getAfter(request: ServerRequest): Long {
+            return getValue(request, "after")?.toLong() ?: 0
+        }
+
+        private fun getCount(request: ServerRequest): Int {
+            val count = getValue(request, "count")
+            return if (count == null) 10
+            else Integer.parseInt(count)
+        }
+
+        fun getPagingFromRequest(req: ServerRequest): Paging {
+            return Paging(after = getAfter(req), count = getCount(req))
+        }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -12,8 +12,8 @@ class PaginationHelper {
             else value.get()
         }
 
-        private fun getAfter(request: ServerRequest): Long {
-            return getValue(request, "after")?.toLong() ?: 0
+        private fun getAfter(request: ServerRequest): Long? {
+            return getValue(request, "after")?.toLong()
         }
 
         private fun getCount(request: ServerRequest): Int {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
@@ -1,0 +1,41 @@
+package com.kroffle.knitting.controller.handler.helper.response
+
+import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemData
+import com.kroffle.knitting.controller.handler.helper.response.type.ListMetaData
+import com.kroffle.knitting.controller.handler.helper.response.type.MetaData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+class ResponseHelper {
+    companion object {
+        private fun makeKnittingResponse(data: ObjectData): APIResponse<ObjectData> =
+            APIResponse(
+                data = data,
+                meta = MetaData(),
+            )
+
+        private fun makeKnittingResponse(data: List<ListItemData>):
+            APIResponse<List<ListItemData>> =
+                APIResponse(
+                    data = data,
+                    meta = ListMetaData(
+                        lastCursor = data.last().getCursor(),
+                    )
+                )
+
+        fun makeJsonResponse(data: ObjectData): Mono<ServerResponse> {
+            return ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(makeKnittingResponse(data))
+        }
+
+        fun makeJsonResponse(data: List<ListItemData>): Mono<ServerResponse> {
+            return ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(makeKnittingResponse(data))
+        }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
@@ -2,7 +2,6 @@ package com.kroffle.knitting.controller.handler.helper.response
 
 import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemData
-import com.kroffle.knitting.controller.handler.helper.response.type.ListMetaData
 import com.kroffle.knitting.controller.handler.helper.response.type.MetaData
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
 import org.springframework.http.MediaType
@@ -18,13 +17,14 @@ class ResponseHelper {
             )
 
         private fun makeKnittingResponse(data: List<ListItemData>):
-            APIResponse<List<ListItemData>> =
-                APIResponse(
-                    data = data,
-                    meta = ListMetaData(
-                        lastCursor = data.last().getCursor(),
-                    )
-                )
+            APIResponse<List<ListItemData>> {
+                val metaData = if (data.isEmpty()) {
+                    MetaData()
+                } else {
+                    MetaData(lastCursor = data.last().getCursor())
+                }
+                return APIResponse(data, metaData)
+            }
 
         fun makeJsonResponse(data: ObjectData): Mono<ServerResponse> {
             return ServerResponse.ok()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/APIResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/APIResponse.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+data class APIResponse<Data>(
+    val data: Data,
+    val meta: MetaData,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemData.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+interface ListItemData : ObjectData {
+    fun getCursor(): String
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemData.kt
@@ -1,5 +1,8 @@
 package com.kroffle.knitting.controller.handler.helper.response.type
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 interface ListItemData : ObjectData {
+    @JsonIgnore
     fun getCursor(): String
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListMetaData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListMetaData.kt
@@ -1,8 +1,0 @@
-package com.kroffle.knitting.controller.handler.helper.response.type
-
-import com.fasterxml.jackson.annotation.JsonProperty
-
-data class ListMetaData(
-    @JsonProperty("last_cursor")
-    val lastCursor: String? = null,
-) : MetaData()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListMetaData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListMetaData.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ListMetaData(
+    @JsonProperty("last_cursor")
+    val lastCursor: String? = null,
+) : MetaData()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
@@ -1,3 +1,10 @@
 package com.kroffle.knitting.controller.handler.helper.response.type
 
-open class MetaData
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class MetaData(
+    @JsonProperty("last_cursor")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val lastCursor: String? = null,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+open class MetaData

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ObjectData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ObjectData.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+interface ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/DBDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/DBDesignRepository.kt
@@ -1,9 +1,10 @@
 package com.kroffle.knitting.infra.persistence.design
 
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
 interface DBDesignRepository : ReactiveCrudRepository<DesignEntity, Long> {
-    fun findAllByKnitterId(knitterId: Long): Flux<DesignEntity>
+    fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<DesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/DBDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/DBDesignRepository.kt
@@ -6,5 +6,6 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
 interface DBDesignRepository : ReactiveCrudRepository<DesignEntity, Long> {
+    fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<DesignEntity>
     fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<DesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/R2dbcDesignRepository.kt
@@ -2,7 +2,11 @@ package com.kroffle.knitting.infra.persistence.design
 
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.infra.persistence.design.entity.toDesignEntity
+import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
 import com.kroffle.knitting.usecase.design.DesignRepository
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -12,9 +16,17 @@ class R2dbcDesignRepository(private val dbDesignRepository: DBDesignRepository) 
             .save(design.toDesignEntity())
             .map { it.toDesign() }
 
-    override fun getDesignsByKnitterId(knitterId: Long): Flux<Design> {
-        return dbDesignRepository
-            .findAllByKnitterId(knitterId)
-            .map { it.toDesign() }
+    override fun getDesignsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Design> {
+        return when (sort.direction) {
+            SortDirection.DESC ->
+                dbDesignRepository
+                    .findAllByKnitterIdAndIdBefore(
+                        knitterId = knitterId,
+                        id = paging.after,
+                        pageable = PaginationHelper.makePageRequest(paging, sort)
+                    )
+                    .map { it.toDesign() }
+            else -> throw NotImplementedError()
+        }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/helper/pagination/PaginationHelper.kt
@@ -1,0 +1,15 @@
+package com.kroffle.knitting.infra.persistence.helper.pagination
+
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import org.springframework.data.domain.PageRequest
+
+class PaginationHelper {
+    companion object {
+        fun makePageRequest(paging: Paging, sort: Sort): PageRequest = PageRequest.of(
+            0,
+            paging.count,
+            sort.makeSort(),
+        )
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/helper/pagination/Sort.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/helper/pagination/Sort.kt
@@ -1,0 +1,13 @@
+package com.kroffle.knitting.infra.persistence.helper.pagination
+
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+import org.springframework.data.domain.Sort as R2DBCSort
+
+fun Sort.makeSort(): R2DBCSort {
+    val sort = R2DBCSort.by(this.column)
+    return when (this.direction) {
+        SortDirection.ASC -> sort.ascending()
+        SortDirection.DESC -> sort.descending()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -1,18 +1,25 @@
 package com.kroffle.knitting.usecase.design
 
 import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 class DesignService(private val repository: DesignRepository) {
     fun create(design: Design): Mono<Design> = repository.createDesign(design)
 
-    fun getMyDesign(knitterId: Long): Flux<Design> =
+    fun getMyDesign(filter: MyDesignFilter): Flux<Design> =
         repository
-            .getDesignsByKnitterId(knitterId)
+            .getDesignsByKnitterId(
+                filter.knitterId,
+                filter.paging,
+                filter.sort,
+            )
 
     interface DesignRepository {
         fun createDesign(design: Design): Mono<Design>
-        fun getDesignsByKnitterId(knitterId: Long): Flux<Design>
+        fun getDesignsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Design>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/MyDesignFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/MyDesignFilter.kt
@@ -1,0 +1,10 @@
+package com.kroffle.knitting.usecase.design.dto
+
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+
+data class MyDesignFilter(
+    val knitterId: Long,
+    val paging: Paging,
+    val sort: Sort,
+)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.usecase.helper.pagination.type
+
+data class Paging(
+    val after: Long,
+    val count: Int,
+)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
@@ -1,6 +1,14 @@
 package com.kroffle.knitting.usecase.helper.pagination.type
 
-data class Paging(
-    val after: Long,
+import java.lang.IllegalArgumentException
+
+class Paging(
+    val after: Long?,
     val count: Int,
-)
+) {
+    init {
+        require(this.count in 1..30) {
+            throw IllegalArgumentException("Count must be between 1 and 30")
+        }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Sort.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Sort.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.usecase.helper.pagination.type
+
+data class Sort(
+    val column: String,
+    val direction: SortDirection,
+)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/SortDirection.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/SortDirection.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.usecase.helper.pagination.type
+
+enum class SortDirection {
+    ASC,
+    DESC
+}

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -4,6 +4,7 @@ import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
 import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
+import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
@@ -148,10 +149,10 @@ class LoginRouterTest {
             }
             .exchange()
             .expectStatus().isOk
-            .expectBody<AuthorizedResponse>()
+            .expectBody<APIResponse<AuthorizedResponse>>()
             .returnResult()
             .responseBody!!
-        assert(tokenDecoder.getAuthorizedUserId(result.token) == targetKnitter.id)
+        assert(tokenDecoder.getAuthorizedUserId(result.data.token) == targetKnitter.id)
     }
 
     @Test
@@ -193,11 +194,11 @@ class LoginRouterTest {
             }
             .exchange()
             .expectStatus().isOk
-            .expectBody<AuthorizedResponse>()
+            .expectBody<APIResponse<AuthorizedResponse>>()
             .returnResult()
             .responseBody!!
 
-        assert(tokenDecoder.getAuthorizedUserId(result.token) == newUserId)
+        assert(tokenDecoder.getAuthorizedUserId(result.data.token) == newUserId)
 
         verify(repo).create(
             argThat {
@@ -222,9 +223,9 @@ class LoginRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<RefreshTokenResponse>()
+            .expectBody<APIResponse<RefreshTokenResponse>>()
             .returnResult()
             .responseBody!!
-        assert(TokenDecoder(secretKey).getAuthorizedUserId(result.token) == userId)
+        assert(TokenDecoder(secretKey).getAuthorizedUserId(result.data.token) == userId)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.controller.router.auth
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.ProfileHandler
 import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
+import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
@@ -99,11 +100,11 @@ class ProfileRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<MyProfileResponse>()
+            .expectBody<APIResponse<MyProfileResponse>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(result).isEqualTo(
+        assertThat(result.data).isEqualTo(
             MyProfileResponse(
                 name = "홍길동",
                 email = "test@test.com",

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
+import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignSize
+import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.PatternType
@@ -26,6 +28,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Mono
 
 @WebFluxTest
@@ -57,7 +60,7 @@ class DesignRouterTest {
         tokenDecoder = TokenDecoder(secretKey)
 
         design = DesignEntity(
-            id = null,
+            id = 1,
             knitterId = 1,
             name = "test",
             designType = DesignType.Sweater,
@@ -110,7 +113,7 @@ class DesignRouterTest {
             )
         )
         given(repo.createDesign(any())).willReturn(Mono.just(design))
-        val response = webClient
+        val response: APIResponse<NewDesignResponse> = webClient
             .post()
             .uri("/design/")
             .header("Authorization", "Bearer $token")
@@ -120,26 +123,9 @@ class DesignRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(Design::class.java)
+            .expectBody<APIResponse<NewDesignResponse>>()
             .returnResult()
             .responseBody!!
-        assertThat(response.id).isEqualTo(design.id)
-        assertThat(response.knitterId).isEqualTo(1)
-        assertThat(response.name).isEqualTo("test")
-        assertThat(response.designType).isEqualTo(DesignType.Sweater)
-        assertThat(response.patternType).isEqualTo(PatternType.Text)
-        assertThat(response.gauge.stitches).isEqualTo(23.5)
-        assertThat(response.gauge.rows).isEqualTo(25.0)
-        assertThat(response.needle).isEqualTo("5.0mm")
-        assertThat(response.yarn).isEqualTo("캐시미어 400g")
-        assertThat(response.extra).isEqualTo(null)
-        assertThat(response.price.value).isEqualTo(0)
-        assertThat(response.size.totalLength.value).isEqualTo(1.0)
-        assertThat(response.size.sleeveLength.value).isEqualTo(2.0)
-        assertThat(response.size.shoulderWidth.value).isEqualTo(3.0)
-        assertThat(response.size.bottomWidth.value).isEqualTo(4.0)
-        assertThat(response.size.armholeDepth.value).isEqualTo(5.0)
-        assertThat(response.pattern.value).isEqualTo("# Step1. 코를 10개 잡습니다.")
-        assertThat(response.createdAt).isEqualTo(design.createdAt)
+        assertThat(response.data.id).isEqualTo(design.id)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -3,8 +3,9 @@ package com.kroffle.knitting.controller.router.design
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
-import com.kroffle.knitting.controller.handler.design.dto.MyDesignsResponse
 import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
+import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
+import com.kroffle.knitting.controller.router.design.extension.like
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.infra.jwt.TokenDecoder
@@ -26,6 +27,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Flux
 
 @WebFluxTest
@@ -98,7 +100,7 @@ class DesignsRouterTest {
                 )
             )
 
-        val responseBody: MyDesignsResponse = webClient
+        val responseBody: APIResponse<List<MyDesign>> = webClient
             .get()
             .uri("/designs/my")
             .header("Authorization", "Bearer $token")
@@ -106,12 +108,13 @@ class DesignsRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(MyDesignsResponse::class.java)
+            .expectBody<APIResponse<List<MyDesign>>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(responseBody.designs).isEqualTo(
-            listOf(
+        assertThat(responseBody.data.size).isEqualTo(1)
+        assert(
+            responseBody.data.first().like(
                 MyDesign(
                     id = 1,
                     name = "캔디리더 효정 니트",
@@ -125,7 +128,7 @@ class DesignsRouterTest {
 
     @Test
     fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
-        val responseBody: SalesSummaryResponse = webClient
+        val responseBody: APIResponse<SalesSummaryResponse> = webClient
             .get()
             .uri("/designs/sales-summary/my")
             .header("Authorization", "Bearer $token")
@@ -133,11 +136,11 @@ class DesignsRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(SalesSummaryResponse::class.java)
+            .expectBody<APIResponse<SalesSummaryResponse>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(responseBody).isEqualTo(
+        assertThat(responseBody.data).isEqualTo(
             SalesSummaryResponse(
                 numberOfDesignsOnSales = 1,
                 numberOfDesignsSold = 2,

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -14,14 +14,15 @@ import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.design.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
-import com.kroffle.knitting.usecase.helper.pagination.type.Paging
-import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.verify
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
@@ -69,13 +70,7 @@ class DesignsRouterTest {
 
     @Test
     fun `내가 만든 도안 리스트가 잘 반환되어야 함`() {
-        given(
-            repo.getDesignsByKnitterId(
-                1,
-                Paging(0, 10),
-                Sort("id", SortDirection.DESC)
-            )
-        )
+        given(repo.getDesignsByKnitterId(any(), any(), any()))
             .willReturn(
                 Flux.just(
                     DesignEntity(
@@ -123,6 +118,21 @@ class DesignsRouterTest {
                     tags = listOf("니트", "서술형도안"),
                 ),
             )
+        )
+        verify(repo).getDesignsByKnitterId(
+            argThat { param -> param == 1.toLong() },
+            argThat {
+                param ->
+                assert(param.after == null)
+                assert(param.count == 10)
+                true
+            },
+            argThat {
+                param ->
+                assert(param.column == "id")
+                assert(param.direction == SortDirection.DESC)
+                true
+            },
         )
     }
 

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -13,6 +13,9 @@ import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.design.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -64,7 +67,13 @@ class DesignsRouterTest {
 
     @Test
     fun `내가 만든 도안 리스트가 잘 반환되어야 함`() {
-        given(repo.getDesignsByKnitterId(1))
+        given(
+            repo.getDesignsByKnitterId(
+                1,
+                Paging(0, 10),
+                Sort("id", SortDirection.DESC)
+            )
+        )
             .willReturn(
                 Flux.just(
                     DesignEntity(

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/extension/MyDesign.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/extension/MyDesign.kt
@@ -1,0 +1,12 @@
+package com.kroffle.knitting.controller.router.design.extension
+
+import com.kroffle.knitting.controller.handler.design.dto.MyDesign
+
+fun MyDesign.like(other: MyDesign): Boolean {
+    if (this === other) return true
+    return id == other.id &&
+        name == other.name &&
+        yarn == other.yarn &&
+        thumbnailImageUrl == other.thumbnailImageUrl &&
+        tags == other.tags
+}


### PR DESCRIPTION
## PR 제안 사유

내가 만든 도안 리스트에서 페이지네이션을 할 수 있도록 구현합니다.

resolves: #82 

## 주요 변경 기록
- 페이지네이션 관련 인자를 받을 수 있도록 API 스펙을 수정합니다.
- request context에서 userId를 가지고 오는 로직의 중복을 최소화 시킵니다.
- API 응답 형태를 통일시키고, 리스트 타입의 응답인 경우 마지막 커서를 내려줄 수 있도록 합니다.

> object 타입의 응답
```json
{
    "data": {
        "id": 1
    },
    "meta": {}
}
```

> list타입의 응답
```json
{
    "data": [
        {
            "id": 1
        },
        {
            "id": 2
        },
        {
            "id": 3
        }
    ],
    "meta": {
        "last_cursor": "3"
    }
}
```

> 페이지네이션 요청

https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-4a7fef63-2504-4ab1-829e-1bc199fe954a