### PR TITLE
chore: deploy job이 main 브랜치에 머지되었을 때 실행될 수 있도록 수정합니다.

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -61,7 +61,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   deploy:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

## PR 제안 사유
머지 되고 난 후 deploy 잡이 돌지 않는 문제가 여전히 있어서 수정합니다.

이번에는 develop 브랜치에서 별도로 테스트 해봤습니다.
- 머지한 PR: https://github.com/k-roffle/knitting-service/pull/93
- 확인한 action: https://github.com/k-roffle/knitting-service/runs/3357431940

## 주요 변경 기록
- deploy job 도는 조건 수정
