### PR TITLE
feat: 상품 구성 Mock API 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -15,6 +15,7 @@ import com.kroffle.knitting.controller.router.auth.ProfileRouter.Companion.PUBLI
 import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
 import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_PATHS as PingRouterPublicPaths
+import com.kroffle.knitting.controller.router.product.ProductRouter.Companion.PUBLIC_PATHS as ProductRouterPublicPaths
 
 @Component
 class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
@@ -68,7 +69,8 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
                 ProfileRouterPublicPaths +
                 DesignRouterPublicPaths +
                 DesignsRouterPublicPaths +
-                PingRouterPublicPaths
+                PingRouterPublicPaths +
+                ProductRouterPublicPaths
             )
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -4,7 +4,7 @@ import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
 import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
-import com.kroffle.knitting.controller.handler.exception.BadRequest
+import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
@@ -28,7 +28,7 @@ class DesignHandler(private val service: DesignService) {
     fun createDesign(req: ServerRequest): Mono<ServerResponse> {
         val design: Mono<NewDesignRequest> = req
             .bodyToMono(NewDesignRequest::class.java)
-            .switchIfEmpty(Mono.error(BadRequest("Body is required")))
+            .switchIfEmpty(Mono.error(EmptyBodyException()))
         val knitterId = AuthHelper.getKnitterId(req)
         return design
             .flatMap {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
@@ -3,4 +3,4 @@ package com.kroffle.knitting.controller.handler.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-class BadRequest(message: String) : ResponseStatusException(HttpStatus.BAD_REQUEST, message)
+open class BadRequest(message: String) : ResponseStatusException(HttpStatus.BAD_REQUEST, message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/EmptyBodyException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/EmptyBodyException.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.exception
+
+class EmptyBodyException : BadRequest("Body is required")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -1,0 +1,51 @@
+package com.kroffle.knitting.controller.handler.product
+
+import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
+import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
+import com.kroffle.knitting.controller.handler.product.dto.DraftProductPackageRequest
+import com.kroffle.knitting.controller.handler.product.dto.DraftProductPackageResponse
+import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.domain.value.Money
+import com.kroffle.knitting.usecase.product.ProductService
+import com.kroffle.knitting.usecase.product.dto.DraftProductPackage
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+@Component
+class ProductHandler(private val productService: ProductService) {
+    fun draftProductPackage(req: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(req)
+        val bodyMono: Mono<DraftProductPackageRequest> = req
+            .bodyToMono(DraftProductPackageRequest::class.java)
+            .switchIfEmpty(Mono.error(EmptyBodyException()))
+
+        val product: Mono<Product> = bodyMono.flatMap {
+            body ->
+            productService.draft(
+                DraftProductPackage(
+                    knitterId = knitterId,
+                    name = body.name,
+                    fullPrice = Money(body.fullPrice),
+                    discountPrice = Money(body.discountPrice),
+                    representativeImageUrl = body.representativeImageUrl,
+                    specifiedSalesStartDate = body.specifiedSalesStartDate,
+                    specifiedSalesEndDate = body.specifiedSalesEndDate,
+                    tags = body.tags,
+                    designIds = body.designIds,
+                    goodsIds = listOf(),
+                )
+            )
+        }
+
+        return product
+            .flatMap {
+                ResponseHelper
+                    .makeJsonResponse(
+                        DraftProductPackageResponse(it.id!!)
+                    )
+            }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageRequest.kt
@@ -1,0 +1,22 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+
+data class DraftProductPackageRequest(
+    val id: Long?,
+    val name: String,
+    @JsonProperty("full_price")
+    val fullPrice: Int,
+    @JsonProperty("discount_price")
+    val discountPrice: Int,
+    @JsonProperty("representative_image_url")
+    val representativeImageUrl: String,
+    @JsonProperty("specified_sales_start_date")
+    val specifiedSalesStartDate: LocalDate?,
+    @JsonProperty("specified_sales_end_date")
+    val specifiedSalesEndDate: LocalDate?,
+    val tags: List<String>,
+    @JsonProperty("design_ids")
+    val designIds: List<Long>,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageResponse.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+
+data class DraftProductPackageResponse(
+    val id: Long,
+) : ObjectData

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
@@ -1,0 +1,28 @@
+package com.kroffle.knitting.controller.router.product
+
+import com.kroffle.knitting.controller.handler.product.ProductHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RequestPredicates.path
+import org.springframework.web.reactive.function.server.RouterFunctions.nest
+import org.springframework.web.reactive.function.server.router
+
+@Configuration
+class ProductRouter(private val handler: ProductHandler) {
+
+    @Bean
+    fun productRouterFunction() = nest(
+        path(ROOT_PATH),
+        router {
+            listOf(
+                POST(DRAFT_PRODUCT_PACKAGE_PATH, handler::draftProductPackage),
+            )
+        }
+    )
+
+    companion object {
+        private const val ROOT_PATH = "/product"
+        private const val DRAFT_PRODUCT_PACKAGE_PATH = "/package"
+        val PUBLIC_PATHS = listOf<String>()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidDiscountPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidDiscountPrice.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.domain.exception
+
+class InvalidDiscountPrice : DomainException("discount price must be between 0 and full price")

--- a/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidDiscountPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidDiscountPrice.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.domain.exception
-
-class InvalidDiscountPrice : DomainException("discount price must be between 0 and full price")

--- a/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidPeriod.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/exception/InvalidPeriod.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.domain.exception
-
-class InvalidPeriod : DomainException("end date must be greater than start date")

--- a/src/main/kotlin/com/kroffle/knitting/domain/exception/UnableToRegister.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/exception/UnableToRegister.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.domain.exception
-
-class UnableToRegister : DomainException("unable to register because of domain fields")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.domain.product.entity
 
+import com.kroffle.knitting.domain.exception.InvalidDiscountPrice
 import com.kroffle.knitting.domain.exception.InvalidPeriod
 import com.kroffle.knitting.domain.exception.UnableToRegister
 import com.kroffle.knitting.domain.product.enum.InputStatus
@@ -31,6 +32,13 @@ class Product(
                 specifiedSalesStartDate > specifiedSalesEndDate
         ) {
             throw InvalidPeriod()
+        }
+
+        require(
+            Money.MIN < discountPrice &&
+                discountPrice <= fullPrice
+        ) {
+            throw InvalidDiscountPrice()
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.domain.product.entity
 
-import com.kroffle.knitting.domain.exception.InvalidDiscountPrice
-import com.kroffle.knitting.domain.exception.InvalidPeriod
-import com.kroffle.knitting.domain.exception.UnableToRegister
+import com.kroffle.knitting.domain.product.exception.InvalidDiscountPrice
+import com.kroffle.knitting.domain.product.exception.InvalidPeriod
+import com.kroffle.knitting.domain.product.exception.UnableToRegister
 import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.domain.product.enum.SalesStatus
 import com.kroffle.knitting.domain.value.Money
@@ -119,7 +119,7 @@ class Product(
             designIds: List<Long>,
         ): Product {
             return Product(
-                null,
+                1, // FIXME
                 knitterId,
                 name,
                 fullPrice,

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -106,7 +106,7 @@ class Product(
     }
 
     companion object {
-        fun draft(
+        fun draftProductPackage(
             knitterId: Long,
             name: String,
             fullPrice: Money,

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -36,13 +36,13 @@ class Product(
         }
 
         require(
-            Money.MIN < discountPrice &&
+            Money.ZERO < discountPrice &&
                 discountPrice <= fullPrice
         ) {
             throw InvalidDiscountPrice()
         }
 
-        require(fullPrice > Money.MIN) {
+        require(fullPrice > Money.ZERO) {
             throw InvalidFullPrice()
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -1,10 +1,11 @@
 package com.kroffle.knitting.domain.product.entity
 
-import com.kroffle.knitting.domain.product.exception.InvalidDiscountPrice
-import com.kroffle.knitting.domain.product.exception.InvalidPeriod
-import com.kroffle.knitting.domain.product.exception.UnableToRegister
 import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.domain.product.enum.SalesStatus
+import com.kroffle.knitting.domain.product.exception.InvalidDiscountPrice
+import com.kroffle.knitting.domain.product.exception.InvalidFullPrice
+import com.kroffle.knitting.domain.product.exception.InvalidPeriod
+import com.kroffle.knitting.domain.product.exception.UnableToRegister
 import com.kroffle.knitting.domain.value.Money
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -39,6 +40,10 @@ class Product(
                 discountPrice <= fullPrice
         ) {
             throw InvalidDiscountPrice()
+        }
+
+        require(fullPrice > Money.MIN) {
+            throw InvalidFullPrice()
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidDiscountPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidDiscountPrice.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.domain.product.exception
+
+import com.kroffle.knitting.domain.exception.DomainException
+
+class InvalidDiscountPrice : DomainException("discount price must be between 0 and full price")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidFullPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidFullPrice.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.domain.product.exception
+
+import com.kroffle.knitting.domain.exception.DomainException
+
+class InvalidFullPrice : DomainException("full price must be greater than 0")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidPeriod.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidPeriod.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.domain.product.exception
+
+import com.kroffle.knitting.domain.exception.DomainException
+
+class InvalidPeriod : DomainException("end date must be greater than start date")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/UnableToRegister.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/UnableToRegister.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.domain.product.exception
+
+import com.kroffle.knitting.domain.exception.DomainException
+
+class UnableToRegister : DomainException("unable to register because of domain fields")

--- a/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
@@ -1,3 +1,10 @@
 package com.kroffle.knitting.domain.value
 
-class Money(val value: Int)
+class Money(val value: Int) {
+    operator fun compareTo(money: Money): Int =
+        this.value.compareTo(money.value)
+
+    companion object {
+        val MIN = Money(0)
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
@@ -5,6 +5,6 @@ class Money(val value: Int) {
         this.value.compareTo(money.value)
 
     companion object {
-        val MIN = Money(0)
+        val ZERO = Money(0)
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -1,0 +1,24 @@
+package com.kroffle.knitting.usecase.product
+
+import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.usecase.product.dto.DraftProductPackage
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class ProductService {
+    fun draft(product: DraftProductPackage): Mono<Product> = Mono.just(
+        Product.draftProductPackage(
+            knitterId = product.knitterId,
+            name = product.name,
+            fullPrice = product.fullPrice,
+            discountPrice = product.discountPrice,
+            representativeImageUrl = product.representativeImageUrl,
+            specifiedSalesStartDate = product.specifiedSalesStartDate,
+            specifiedSalesEndDate = product.specifiedSalesEndDate,
+            tags = product.tags,
+            goodsIds = product.goodsIds,
+            designIds = product.designIds,
+        )
+    )
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/DraftProductPackage.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/DraftProductPackage.kt
@@ -1,0 +1,17 @@
+package com.kroffle.knitting.usecase.product.dto
+
+import com.kroffle.knitting.domain.value.Money
+import java.time.LocalDate
+
+data class DraftProductPackage(
+    val knitterId: Long,
+    val name: String,
+    val fullPrice: Money,
+    val discountPrice: Money,
+    val representativeImageUrl: String,
+    val specifiedSalesStartDate: LocalDate?,
+    val specifiedSalesEndDate: LocalDate?,
+    val tags: List<String>,
+    val goodsIds: List<Long>,
+    val designIds: List<Long>,
+)


### PR DESCRIPTION
## PR 제안 사유
- 상품 구성을 추가 할 수 있는 mock api를 구현합니다.
  - usecase에 대한 구현은 다음 PR에서 구현합니다.
 

## 주요 변경 기록
- money compare 함수 구현
- discountPrice, fullPrice 제약조건 추가
- Product.draft 함수 이름 변경
- 상품 구성 draft API presentation 레이어 구현

## API

https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-bdfc6847-83d4-4a0d-8d60-d57381072cb6

여기에서 request, response example을 볼 수 있습니다.