### PR TITLE
refactor: response에서 data키를 payload로 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/AuthorizedResponse.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
-class AuthorizedResponse(val token: String) : ObjectData
+class AuthorizedResponse(val token: String) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/MyProfileResponse.kt
@@ -1,11 +1,11 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 data class MyProfileResponse(
     val email: String,
     @JsonProperty("profile_image_url")
     val profileImageUrl: String?,
     val name: String?,
-) : ObjectData
+) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/dto/RefreshTokenResponse.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.controller.handler.auth.dto
 
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
-class RefreshTokenResponse(val token: String) : ObjectData
+class RefreshTokenResponse(val token: String) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kroffle.knitting.controller.handler.helper.response.type.ListItemData
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
 
 class MyDesign(
     val id: Long,
@@ -10,6 +10,6 @@ class MyDesign(
     @JsonProperty("cover_image_url")
     val coverImageUrl: String,
     val tags: List<String>,
-) : ListItemData {
+) : ListItemPayload {
     override fun getCursor(): String = id.toString()
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignResponse.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 data class NewDesignResponse(
     val id: Long,
-) : ObjectData
+) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SalesSummaryResponse.kt
@@ -1,11 +1,11 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 data class SalesSummaryResponse(
     @JsonProperty("number_of_designs_on_sales")
     val numberOfDesignsOnSales: Int,
     @JsonProperty("number_of_designs_sold")
     val numberOfDesignsSold: Int,
-) : ObjectData
+) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
@@ -1,38 +1,42 @@
 package com.kroffle.knitting.controller.handler.helper.response
 
-import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
-import com.kroffle.knitting.controller.handler.helper.response.type.ListItemData
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
 import com.kroffle.knitting.controller.handler.helper.response.type.MetaData
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
 class ResponseHelper {
+    private class Response<T>(
+        val payload: T,
+        val meta: MetaData,
+    )
+
     companion object {
-        private fun makeKnittingResponse(data: ObjectData): APIResponse<ObjectData> =
-            APIResponse(
-                data = data,
+        private fun makeKnittingResponse(payload: ObjectPayload): Response<ObjectPayload> =
+            Response(
+                payload = payload,
                 meta = MetaData(),
             )
 
-        private fun makeKnittingResponse(data: List<ListItemData>):
-            APIResponse<List<ListItemData>> {
+        private fun makeKnittingResponse(data: List<ListItemPayload>):
+            Response<List<ListItemPayload>> {
                 val metaData = if (data.isEmpty()) {
                     MetaData()
                 } else {
                     MetaData(lastCursor = data.last().getCursor())
                 }
-                return APIResponse(data, metaData)
+                return Response(data, metaData)
             }
 
-        fun makeJsonResponse(data: ObjectData): Mono<ServerResponse> {
+        fun makeJsonResponse(data: ObjectPayload): Mono<ServerResponse> {
             return ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(makeKnittingResponse(data))
         }
 
-        fun makeJsonResponse(data: List<ListItemData>): Mono<ServerResponse> {
+        fun makeJsonResponse(data: List<ListItemPayload>): Mono<ServerResponse> {
             return ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(makeKnittingResponse(data))

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/APIResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/APIResponse.kt
@@ -1,6 +1,0 @@
-package com.kroffle.knitting.controller.handler.helper.response.type
-
-data class APIResponse<Data>(
-    val data: Data,
-    val meta: MetaData,
-)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemPayload.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ListItemPayload.kt
@@ -2,7 +2,7 @@ package com.kroffle.knitting.controller.handler.helper.response.type
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 
-interface ListItemData : ObjectData {
+interface ListItemPayload : Payload {
     @JsonIgnore
     fun getCursor(): String
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ObjectPayload.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/ObjectPayload.kt
@@ -1,3 +1,3 @@
 package com.kroffle.knitting.controller.handler.helper.response.type
 
-interface ObjectData
+interface ObjectPayload : Payload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/Payload.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/Payload.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.controller.handler.helper.response.type
+
+interface Payload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductPackageResponse.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.kroffle.knitting.controller.handler.helper.response.type.ObjectData
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 data class DraftProductPackageResponse(
     val id: Long,
-) : ObjectData
+) : ObjectPayload

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -4,8 +4,8 @@ import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
 import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
-import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.domain.knitter.entity.Knitter
+import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
@@ -149,10 +149,10 @@ class LoginRouterTest {
             }
             .exchange()
             .expectStatus().isOk
-            .expectBody<APIResponse<AuthorizedResponse>>()
+            .expectBody<TestResponse<AuthorizedResponse>>()
             .returnResult()
             .responseBody!!
-        assert(tokenDecoder.getKnitterId(result.data.token) == targetKnitter.id)
+        assert(tokenDecoder.getKnitterId(result.payload.token) == targetKnitter.id)
     }
 
     @Test
@@ -194,11 +194,11 @@ class LoginRouterTest {
             }
             .exchange()
             .expectStatus().isOk
-            .expectBody<APIResponse<AuthorizedResponse>>()
+            .expectBody<TestResponse<AuthorizedResponse>>()
             .returnResult()
             .responseBody!!
 
-        assert(tokenDecoder.getKnitterId(result.data.token) == newKnitterId)
+        assert(tokenDecoder.getKnitterId(result.payload.token) == newKnitterId)
 
         verify(repo).create(
             argThat {
@@ -223,9 +223,9 @@ class LoginRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<APIResponse<RefreshTokenResponse>>()
+            .expectBody<TestResponse<RefreshTokenResponse>>()
             .returnResult()
             .responseBody!!
-        assert(TokenDecoder(secretKey).getKnitterId(result.data.token) == knitterId)
+        assert(TokenDecoder(secretKey).getKnitterId(result.payload.token) == knitterId)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/ProfileRouterTest.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.controller.router.auth
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.ProfileHandler
 import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
-import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
+import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
@@ -100,11 +100,11 @@ class ProfileRouterTest {
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
-            .expectBody<APIResponse<MyProfileResponse>>()
+            .expectBody<TestResponse<MyProfileResponse>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(result.data).isEqualTo(
+        assertThat(result.payload).isEqualTo(
             MyProfileResponse(
                 name = "홍길동",
                 email = "test@test.com",

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -6,11 +6,11 @@ import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignSize
-import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.LevelType
 import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
@@ -118,7 +118,7 @@ class DesignRouterTest {
             )
         )
         given(repo.createDesign(any())).willReturn(Mono.just(design))
-        val response: APIResponse<NewDesignResponse> = webClient
+        val response: TestResponse<NewDesignResponse> = webClient
             .post()
             .uri("/design/")
             .header("Authorization", "Bearer $token")
@@ -128,9 +128,9 @@ class DesignRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody<APIResponse<NewDesignResponse>>()
+            .expectBody<TestResponse<NewDesignResponse>>()
             .returnResult()
             .responseBody!!
-        assertThat(response.data.id).isEqualTo(design.id)
+        assertThat(response.payload.id).isEqualTo(design.id)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -4,11 +4,11 @@ import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
-import com.kroffle.knitting.controller.handler.helper.response.type.APIResponse
 import com.kroffle.knitting.controller.router.design.extension.like
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.LevelType
 import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
@@ -98,7 +98,7 @@ class DesignsRouterTest {
                 )
             )
 
-        val responseBody: APIResponse<List<MyDesign>> = webClient
+        val responseBody: TestResponse<List<MyDesign>> = webClient
             .get()
             .uri("/designs/my")
             .header("Authorization", "Bearer $token")
@@ -106,13 +106,13 @@ class DesignsRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody<APIResponse<List<MyDesign>>>()
+            .expectBody<TestResponse<List<MyDesign>>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(responseBody.data.size).isEqualTo(1)
+        assertThat(responseBody.payload.size).isEqualTo(1)
         assert(
-            responseBody.data.first().like(
+            responseBody.payload.first().like(
                 MyDesign(
                     id = 1,
                     name = "캔디리더 효정 니트",
@@ -141,7 +141,7 @@ class DesignsRouterTest {
 
     @Test
     fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
-        val responseBody: APIResponse<SalesSummaryResponse> = webClient
+        val responseBody: TestResponse<SalesSummaryResponse> = webClient
             .get()
             .uri("/designs/sales-summary/my")
             .header("Authorization", "Bearer $token")
@@ -149,11 +149,11 @@ class DesignsRouterTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody<APIResponse<SalesSummaryResponse>>()
+            .expectBody<TestResponse<SalesSummaryResponse>>()
             .returnResult()
             .responseBody!!
 
-        assertThat(responseBody.data).isEqualTo(
+        assertThat(responseBody.payload).isEqualTo(
             SalesSummaryResponse(
                 numberOfDesignsOnSales = 1,
                 numberOfDesignsSold = 2,

--- a/src/test/kotlin/com/kroffle/knitting/helper/TestResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/TestResponse.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.helper
+
+import com.kroffle.knitting.controller.handler.helper.response.type.MetaData
+
+class TestResponse<T>(
+    val payload: T,
+    val meta: MetaData,
+)


### PR DESCRIPTION
## PR 제안 사유

이슈 참고

Resolves #101 

## 주요 변경 기록
- Data라는 네이밍 Payload로 변경
- APIResponse class를 private으로 변경한 후 Response로 네이밍 변경
  - 외부에서 Helper를 거치지 않고 Response를 내려주지 않도록 제한하기 위함
- ListItemPayload가 ObjectPayload가 아닌 Payload상속 받도록 수정
