### PR TITLE
feat: add created_at field to my designs api

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -97,7 +97,8 @@ class DesignHandler(private val service: DesignService) {
                     name = design.name,
                     yarn = design.yarn,
                     coverImageUrl = design.coverImageUrl,
-                    tags = listOf(design.designType.tag, design.patternType.tag)
+                    tags = listOf(design.designType.tag, design.patternType.tag),
+                    createdAt = design.createdAt!!,
                 )
             }
             .collect(toList())

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesign.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
+import java.time.LocalDateTime
 
 class MyDesign(
     val id: Long,
@@ -10,6 +11,8 @@ class MyDesign(
     @JsonProperty("cover_image_url")
     val coverImageUrl: String,
     val tags: List<String>,
+    @JsonProperty("created_at")
+    val createdAt: LocalDateTime,
 ) : ListItemPayload {
     override fun getCursor(): String = id.toString()
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -31,6 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Flux
+import java.time.LocalDateTime
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -54,6 +55,8 @@ class DesignsRouterTest {
     private val secretKey = "I'M SECRET KEY!"
 
     private val knitterId: Long = 1
+
+    private val today: LocalDateTime = LocalDateTime.now()
 
     @BeforeEach
     fun setUp() {
@@ -94,6 +97,7 @@ class DesignsRouterTest {
                         description = "이건 니트를 만드는 서술형 도안입니다.",
                         targetLevel = LevelType.HARD.key,
                         coverImageUrl = "http://test.kroffle.com/image.jpg",
+                        createdAt = today,
                     ).toDesign()
                 )
             )
@@ -119,6 +123,7 @@ class DesignsRouterTest {
                     yarn = "패션아란 400g 1볼",
                     coverImageUrl = "http://test.kroffle.com/image.jpg",
                     tags = listOf("니트", "서술형도안"),
+                    createdAt = today,
                 ),
             )
         )

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/extension/MyDesign.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/extension/MyDesign.kt
@@ -8,5 +8,6 @@ fun MyDesign.like(other: MyDesign): Boolean {
         name == other.name &&
         yarn == other.yarn &&
         coverImageUrl == other.coverImageUrl &&
-        tags == other.tags
+        tags == other.tags &&
+        createdAt == other.createdAt
 }


### PR DESCRIPTION
## PR 제안 사유

이슈 참고

Resolves #103 

## 주요 변경 기록
- 내 디자인 조회 API 응답에 created_at 추가