### PR TITLE
refactor: 테스트 코드 전체 리팩토링 

### DIFF
--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -56,6 +56,16 @@ class LoginRouterTest {
 
     @BeforeEach
     fun setUp() {
+        val oAuthHelper = GoogleOAuthHelperImpl(
+            ClientInfo(
+                "http",
+                "localhost:2028"
+            ),
+            GoogleOAuthConfig(
+                "GOOGLE_CLIENT_ID",
+                "GOOGLE_SECRET_KEY",
+            ),
+        )
         tokenPublisher = TokenPublisher(WebTestClientHelper.JWT_SECRET_KEY)
         tokenDecoder = TokenDecoder(WebTestClientHelper.JWT_SECRET_KEY)
 
@@ -63,20 +73,7 @@ class LoginRouterTest {
             .createWebTestClient(
                 LogInRouter(
                     GoogleLogInHandler(
-                        AuthService(
-                            GoogleOAuthHelperImpl(
-                                ClientInfo(
-                                    "http",
-                                    "localhost:2028"
-                                ),
-                                GoogleOAuthConfig(
-                                    "GOOGLE_CLIENT_ID",
-                                    "GOOGLE_SECRET_KEY",
-                                ),
-                            ),
-                            tokenPublisher,
-                            repository,
-                        ),
+                        AuthService(oAuthHelper, tokenPublisher, repository),
                     )
                 ).logInRouterFunction()
             )

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -1,11 +1,12 @@
 package com.kroffle.knitting.controller.router.auth
 
-import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.auth.GoogleLogInHandler
 import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.helper.TestResponse
+import com.kroffle.knitting.helper.WebTestClientHelper
+import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
@@ -36,7 +37,7 @@ import java.time.LocalDateTime
 class LoginRouterTest {
     private lateinit var webClient: WebTestClient
 
-    private lateinit var tokenPublisher: TokenPublisher
+    private lateinit var webClientWithMockOAuthHelper: WebTestClient
 
     @MockBean
     private lateinit var mockOAuthHelper: AuthService.OAuthHelper
@@ -45,53 +46,49 @@ class LoginRouterTest {
     private lateinit var tokenDecoder: TokenDecoder
 
     @MockBean
-    lateinit var repo: KnitterRepository
+    private lateinit var tokenPublisher: TokenPublisher
+
+    @MockBean
+    private lateinit var repository: KnitterRepository
 
     @MockBean
     private lateinit var webProperties: WebApplicationProperties
 
-    private val secretKey = "I'M SECRET KEY!"
-
     @BeforeEach
     fun setUp() {
+        tokenPublisher = TokenPublisher(WebTestClientHelper.JWT_SECRET_KEY)
+        tokenDecoder = TokenDecoder(WebTestClientHelper.JWT_SECRET_KEY)
 
-        tokenPublisher = TokenPublisher(secretKey)
-        tokenDecoder = TokenDecoder(secretKey)
-
-        val routerFunction = LogInRouter(
-            GoogleLogInHandler(
-                AuthService(
-                    GoogleOAuthHelperImpl(
-                        ClientInfo(
-                            "http",
-                            "localhost:2028"
+        webClient = WebTestClientHelper
+            .createWebTestClient(
+                LogInRouter(
+                    GoogleLogInHandler(
+                        AuthService(
+                            GoogleOAuthHelperImpl(
+                                ClientInfo(
+                                    "http",
+                                    "localhost:2028"
+                                ),
+                                GoogleOAuthConfig(
+                                    "GOOGLE_CLIENT_ID",
+                                    "GOOGLE_SECRET_KEY",
+                                ),
+                            ),
+                            tokenPublisher,
+                            repository,
                         ),
-                        GoogleOAuthConfig(
-                            "GOOGLE_CLIENT_ID",
-                            "GOOGLE_SECRET_KEY",
-                        ),
-                    ),
-                    tokenPublisher,
-                    repo,
-                ),
+                    )
+                ).logInRouterFunction()
             )
-        ).logInRouterFunction()
-        webClient = WebTestClient
-            .bindToRouterFunction(routerFunction)
-            .webFilter<WebTestClient.RouterFunctionSpec>(AuthorizationFilter(tokenDecoder))
-            .build()
-    }
 
-    private fun setWebClientWithMockOAuthHelper() {
-        val routerFunction = LogInRouter(
-            GoogleLogInHandler(
-                AuthService(mockOAuthHelper, tokenPublisher, repo),
+        webClientWithMockOAuthHelper = WebTestClientHelper
+            .createWebTestClient(
+                LogInRouter(
+                    GoogleLogInHandler(
+                        AuthService(mockOAuthHelper, tokenPublisher, repository),
+                    )
+                ).logInRouterFunction()
             )
-        ).logInRouterFunction()
-        webClient = WebTestClient
-            .bindToRouterFunction(routerFunction)
-            .webFilter<WebTestClient.RouterFunctionSpec>(AuthorizationFilter(tokenDecoder))
-            .build()
     }
 
     @Test
@@ -115,7 +112,6 @@ class LoginRouterTest {
 
     @Test
     fun `이미 가입한 유저인 경우 access token 을 발급 받을 수 있어야 함`() {
-        setWebClientWithMockOAuthHelper()
         val targetKnitter = KnitterEntity(
             id = 1,
             email = "mock@email.com",
@@ -134,11 +130,11 @@ class LoginRouterTest {
             )
         )
 
-        given(repo.findByEmail(targetKnitter.email)).willReturn(
+        given(repository.findByEmail(targetKnitter.email)).willReturn(
             Mono.just(targetKnitter)
         )
 
-        val result = webClient
+        val result = webClientWithMockOAuthHelper
             .get()
             .uri {
                 uriBuilder ->
@@ -157,7 +153,6 @@ class LoginRouterTest {
 
     @Test
     fun `새로 가입하는 유저의 경우 계정을 생성한 후 access token 을 발급 받을 수 있어야 함`() {
-        setWebClientWithMockOAuthHelper()
         val newKnitterId: Long = 1
         val newUserCreatedAt = LocalDateTime.now()
         val mockUser = Knitter(
@@ -178,12 +173,13 @@ class LoginRouterTest {
             )
         )
 
-        given(repo.findByEmail(mockUser.email)).willReturn(Mono.empty())
+        given(repository.findByEmail(mockUser.email))
+            .willReturn(Mono.empty())
 
-        given(repo.create(any()))
+        given(repository.create(any()))
             .willReturn(Mono.just(mockUser))
 
-        val result = webClient
+        val result = webClientWithMockOAuthHelper
             .get()
             .uri {
                 uriBuilder ->
@@ -200,7 +196,7 @@ class LoginRouterTest {
 
         assert(tokenDecoder.getKnitterId(result.payload.token) == newKnitterId)
 
-        verify(repo).create(
+        verify(repository).create(
             argThat {
                 param ->
                 assert(param.id == null)
@@ -215,17 +211,17 @@ class LoginRouterTest {
 
     @Test
     fun `리프레시 요청시 동일한 유저 id로 토큰이 갱신 되어야 함`() {
-        val knitterId: Long = 1
-        val token = tokenPublisher.publish(knitterId)
         val result = webClient
             .post()
             .uri("/auth/refresh")
-            .header("Authorization", "Bearer $token")
+            .addDefaultRequestHeader()
             .exchange()
             .expectStatus().isOk
             .expectBody<TestResponse<RefreshTokenResponse>>()
             .returnResult()
             .responseBody!!
-        assert(TokenDecoder(secretKey).getKnitterId(result.payload.token) == knitterId)
+        val decodedToken = TokenDecoder(WebTestClientHelper.JWT_SECRET_KEY)
+            .getKnitterId(result.payload.token)
+        assert(decodedToken == WebTestClientHelper.AUTHORIZED_KNITTER_ID)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/ping/PingRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/ping/PingRouterTest.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.router.ping
 
 import com.kroffle.knitting.controller.filter.auth.AuthorizationFilter
 import com.kroffle.knitting.controller.handler.ping.PingHandler
+import com.kroffle.knitting.helper.WebTestClientHelper
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -15,25 +16,25 @@ import org.springframework.test.web.reactive.server.expectBody
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
 class PingRouterTest {
-    lateinit var webClient: WebTestClient
+    private lateinit var webClient: WebTestClient
 
     @MockBean
-    lateinit var tokenDecoder: AuthorizationFilter.TokenDecoder
+    private lateinit var tokenDecoder: AuthorizationFilter.TokenDecoder
 
     @MockBean
     private lateinit var webProperties: WebApplicationProperties
 
     @BeforeEach
     fun setUp() {
-        val routerFunction = PingRouter(PingHandler()).pingRouterFunction()
-        webClient = WebTestClient.bindToRouterFunction(routerFunction).build()
+        webClient = WebTestClientHelper
+            .createWebTestClient(PingRouter(PingHandler()).pingRouterFunction())
     }
 
     @Test
     fun `pong 이 잘 반환되어야 함`() {
         webClient
             .get()
-            .uri("/ping/")
+            .uri("/ping")
             .exchange()
             .expectStatus().isOk
             .expectBody<String>().isEqualTo("pong")

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -130,12 +130,12 @@ class ProductRouterTest {
                         product.inputStatus == createdProduct.inputStatus
                 )
                 product.tags.mapIndexed {
-                    idx, tag ->
-                    assert(createdProduct.tags[idx].tag == tag.tag)
+                    index, tag ->
+                    assert(createdProduct.tags[index].tag == tag.tag)
                 }
                 product.items.mapIndexed {
-                    idx, item ->
-                    assert(createdProduct.items[idx].itemId == item.itemId)
+                    index, item ->
+                    assert(createdProduct.items[index].itemId == item.itemId)
                 }
                 true
             }

--- a/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
@@ -14,6 +14,7 @@ class WebTestClientHelper {
         private const val JWT_SECRET_KEY = "I'M SECRET KEY!"
         private val tokenDecoder = TokenDecoder(JWT_SECRET_KEY)
         private val tokenPublisher = TokenPublisher(JWT_SECRET_KEY)
+        private val token = tokenPublisher.publish(AUTHORIZED_KNITTER_ID)
 
         fun createWebTestClient(routerFunction: RouterFunction<ServerResponse>): WebTestClient {
             return WebTestClient
@@ -29,7 +30,6 @@ class WebTestClientHelper {
         ): WebTestClient.RequestBodySpec {
             val requestWithHeader =
                 if (authorized) {
-                    val token = tokenPublisher.publish(AUTHORIZED_KNITTER_ID)
                     request
                         .header("Authorization", "Bearer $token")
                 } else {
@@ -39,6 +39,23 @@ class WebTestClientHelper {
             return requestWithHeader
                 .accept(mediaType)
                 .contentType(mediaType)
+        }
+
+        fun addDefaultRequestHeader(
+            request: WebTestClient.RequestHeadersSpec<*>,
+            authorized: Boolean = true,
+            mediaType: MediaType = MediaType.APPLICATION_JSON,
+        ): WebTestClient.RequestHeadersSpec<*> {
+            val requestWithHeader =
+                if (authorized) {
+                    request
+                        .header("Authorization", "Bearer $token")
+                } else {
+                    request
+                }
+
+            return requestWithHeader
+                .accept(mediaType)
         }
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.function.server.ServerResponse
 class WebTestClientHelper {
     companion object {
         const val AUTHORIZED_KNITTER_ID: Long = 1
-        private const val JWT_SECRET_KEY = "I'M SECRET KEY!"
+        const val JWT_SECRET_KEY = "I'M SECRET KEY!"
         private val tokenDecoder = TokenDecoder(JWT_SECRET_KEY)
         private val tokenPublisher = TokenPublisher(JWT_SECRET_KEY)
         private val token = tokenPublisher.publish(AUTHORIZED_KNITTER_ID)

--- a/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/WebTestClientHelper.kt
@@ -25,8 +25,8 @@ class WebTestClientHelper {
 
         fun addDefaultRequestHeader(
             request: WebTestClient.RequestBodySpec,
-            authorized: Boolean = true,
-            mediaType: MediaType = MediaType.APPLICATION_JSON,
+            authorized: Boolean,
+            mediaType: MediaType,
         ): WebTestClient.RequestBodySpec {
             val requestWithHeader =
                 if (authorized) {
@@ -43,8 +43,8 @@ class WebTestClientHelper {
 
         fun addDefaultRequestHeader(
             request: WebTestClient.RequestHeadersSpec<*>,
-            authorized: Boolean = true,
-            mediaType: MediaType = MediaType.APPLICATION_JSON,
+            authorized: Boolean,
+            mediaType: MediaType,
         ): WebTestClient.RequestHeadersSpec<*> {
             val requestWithHeader =
                 if (authorized) {

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/RequestHeadersSpec.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/RequestHeadersSpec.kt
@@ -1,0 +1,11 @@
+package com.kroffle.knitting.helper.extension
+
+import com.kroffle.knitting.helper.WebTestClientHelper
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+fun WebTestClient.RequestHeadersSpec<*>.addDefaultRequestHeader(
+    authorized: Boolean = true,
+    mediaType: MediaType = MediaType.APPLICATION_JSON,
+): WebTestClient.RequestHeadersSpec<*> =
+    WebTestClientHelper.addDefaultRequestHeader(this, authorized, mediaType)


### PR DESCRIPTION
## PR 제안 사유

- 테스트에서 중복되는 부분이 많아 리팩토링합니다.
- webClient를 생성하는 부분과 authorized request, header 세팅 하는 중복을 제거합니다.


Resolves #107 

## 주요 변경 기록
- get 요청시에도 default header 붙일 수 있도록 함수 추가
- router별로 helper class 적용
