### PR TITLE
feat: 상품 설명 저장 API

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
@@ -3,4 +3,6 @@ package com.kroffle.knitting.controller.handler.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-open class BadRequest(message: String) : ResponseStatusException(HttpStatus.BAD_REQUEST, message)
+open class BadRequest(
+    message: String? = "Unknown exception raised"
+) : ResponseStatusException(HttpStatus.BAD_REQUEST, message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductContentRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductContentRequest.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+data class DraftProductContentRequest(
+    val id: Long,
+    val content: String,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductContentResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/DraftProductContentResponse.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+
+data class DraftProductContentResponse(
+    val id: Long,
+) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
@@ -16,6 +16,7 @@ class ProductRouter(private val handler: ProductHandler) {
         router {
             listOf(
                 POST(DRAFT_PRODUCT_PACKAGE_PATH, handler::draftProductPackage),
+                POST(DRAFT_PRODUCT_CONTENT_PATH, handler::draftProductContent),
             )
         }
     )
@@ -23,6 +24,7 @@ class ProductRouter(private val handler: ProductHandler) {
     companion object {
         private const val ROOT_PATH = "/product"
         private const val DRAFT_PRODUCT_PACKAGE_PATH = "/package"
+        private const val DRAFT_PRODUCT_CONTENT_PATH = "/content"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -67,7 +67,7 @@ class Product(
             salesStatus == SalesStatus.ON_SALES &&
                 inputStatus == InputStatus.REGISTERED
 
-    fun writeContent(newContent: String): Product {
+    fun draftContent(newContent: String): Product {
         return Product(
             id,
             knitterId,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
@@ -2,5 +2,8 @@ package com.kroffle.knitting.infra.persistence.product.repository
 
 import com.kroffle.knitting.infra.persistence.product.entity.ProductItemEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
 
-interface DBProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long>
+interface DBProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long> {
+    fun findAllByProductId(productId: Long): Flux<ProductItemEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
@@ -2,5 +2,8 @@ package com.kroffle.knitting.infra.persistence.product.repository
 
 import com.kroffle.knitting.infra.persistence.product.entity.ProductTagEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
 
-interface DBProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long>
+interface DBProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long> {
+    fun findAllByProductId(productId: Long): Flux<ProductTagEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -39,6 +39,22 @@ class R2dbcProductRepository(
     }
 
     override fun findById(id: Long): Mono<Product> {
-        TODO("Not yet implemented")
+        val tags = productTagRepository
+            .findAllByProductId(id)
+            .map { it.toTag() }
+            .collect(toList())
+
+        val items = productItemRepository
+            .findAllByProductId(id)
+            .map { it.toItem() }
+            .collect(toList())
+
+        val product = productRepository
+            .findById(id)
+
+        return Mono.zip(product, tags, items)
+            .map {
+                it.t1.toProduct(it.t2, it.t3)
+            }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -37,4 +37,8 @@ class R2dbcProductRepository(
                     }
             }
     }
+
+    override fun findById(id: Long): Mono<Product> {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/exception/NotFoundEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/exception/NotFoundEntity.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.usecase.exception
+
+class NotFoundEntity(clazz: Class<*>) : Exception("Cannot found ${clazz.name}")

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -1,6 +1,8 @@
 package com.kroffle.knitting.usecase.product
 
 import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.usecase.exception.NotFoundEntity
+import com.kroffle.knitting.usecase.product.dto.DraftProductContent
 import com.kroffle.knitting.usecase.product.dto.DraftProductPackage
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
@@ -23,7 +25,21 @@ class ProductService(private val repository: ProductRepository) {
             )
         )
 
+    fun draft(product: DraftProductContent): Mono<Product> {
+        return repository
+            .findById(product.id)
+            .filter {
+                it.knitterId == product.knitterId
+            }
+            .switchIfEmpty(Mono.error(NotFoundEntity(Product::class.java)))
+            .flatMap {
+                repository
+                    .save(it.draftContent(product.content))
+            }
+    }
+
     interface ProductRepository {
         fun save(product: Product): Mono<Product>
+        fun findById(id: Long): Mono<Product>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/DraftProductContent.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/DraftProductContent.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.usecase.product.dto
+
+data class DraftProductContent(
+    val id: Long,
+    val knitterId: Long,
+    val content: String,
+)

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
@@ -1,0 +1,30 @@
+package com.kroffle.knitting.helper.extension
+
+import com.kroffle.knitting.domain.product.entity.Product
+
+fun Product.like(other: Product): Boolean {
+    if (this === other) return true
+    tags.mapIndexed {
+        idx, tag ->
+        if (other.tags[idx].tag != tag.tag) {
+            return false
+        }
+    }
+    items.mapIndexed {
+        idx, item ->
+        if (other.items[idx].itemId != item.itemId) {
+            return false
+        }
+    }
+    return id == other.id &&
+        knitterId == other.knitterId &&
+        name == other.name &&
+        fullPrice.like(other.fullPrice) &&
+        discountPrice.like(other.discountPrice) &&
+        representativeImageUrl == other.representativeImageUrl &&
+        specifiedSalesStartDate == other.specifiedSalesStartDate &&
+        specifiedSalesEndDate == other.specifiedSalesEndDate &&
+        content == other.content &&
+        inputStatus == other.inputStatus &&
+        createdAt == other.createdAt
+}


### PR DESCRIPTION
## PR 제안 사유
- 상품 설명을 저장할 수 있도록 합니다.

Resolves #88 

## 주요 변경 기록
- 상품 설명 API 추가
- 도메인 함수 이름 변경
- BadRequest Exception에 기본 메시지 추가

## API Spec
https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-7e877a90-fa7d-4148-8898-5145eacdc97d


