### PR TITLE
feat: summary API에서 실제 판매중인 상품 개수 보일 수 있도록 수정

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -11,9 +11,9 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
-import com.kroffle.knitting.controller.router.auth.ProfileRouter.Companion.PUBLIC_PATHS as ProfileRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
+import com.kroffle.knitting.controller.router.knitter.MyselfRouter.Companion.PUBLIC_PATHS as MyselfRouterPublicPaths
 import com.kroffle.knitting.controller.router.ping.PingRouter.Companion.PUBLIC_PATHS as PingRouterPublicPaths
 import com.kroffle.knitting.controller.router.product.ProductRouter.Companion.PUBLIC_PATHS as ProductRouterPublicPaths
 
@@ -66,7 +66,7 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
         private const val HEADER_PREFIX = "Bearer "
         private val PUBLIC_PATHS = (
             LogInRouterPublicPaths +
-                ProfileRouterPublicPaths +
+                MyselfRouterPublicPaths +
                 DesignRouterPublicPaths +
                 DesignsRouterPublicPaths +
                 PingRouterPublicPaths +

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -3,7 +3,6 @@ package com.kroffle.knitting.controller.handler.design
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
-import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
@@ -105,15 +104,5 @@ class DesignHandler(private val service: DesignService) {
             .flatMap {
                 ResponseHelper.makeJsonResponse(it)
             }
-    }
-
-    fun getMySalesSummary(req: ServerRequest): Mono<ServerResponse> {
-        return ResponseHelper
-            .makeJsonResponse(
-                SalesSummaryResponse(
-                    numberOfDesignsOnSales = 1,
-                    numberOfDesignsSold = 2,
-                )
-            )
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
@@ -1,8 +1,9 @@
-package com.kroffle.knitting.controller.handler.auth
+package com.kroffle.knitting.controller.handler.knitter
 
-import com.kroffle.knitting.controller.handler.auth.dto.MyProfileResponse
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
+import com.kroffle.knitting.controller.handler.knitter.dto.MyProfileResponse
+import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummaryResponse
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -10,7 +11,7 @@ import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
 @Component
-class ProfileHandler(private val authService: AuthService) {
+class MyselfHandler(private val authService: AuthService) {
     fun getMyProfile(req: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(req)
         return authService
@@ -26,5 +27,15 @@ class ProfileHandler(private val authService: AuthService) {
             .flatMap {
                 ResponseHelper.makeJsonResponse(it)
             }
+    }
+
+    fun getMySalesSummary(req: ServerRequest): Mono<ServerResponse> {
+        return ResponseHelper
+            .makeJsonResponse(
+                SalesSummaryResponse(
+                    numberOfDesignsOnSales = 1,
+                    numberOfDesignsSold = 2,
+                )
+            )
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
@@ -4,17 +4,17 @@ import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.controller.handler.knitter.dto.MyProfileResponse
 import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummaryResponse
-import com.kroffle.knitting.usecase.auth.AuthService
+import com.kroffle.knitting.usecase.knitter.KnitterService
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
 @Component
-class MyselfHandler(private val authService: AuthService) {
+class MyselfHandler(private val knitterService: KnitterService) {
     fun getMyProfile(req: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(req)
-        return authService
+        return knitterService
             .getKnitter(knitterId)
             .map {
                 knitter ->

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/MyProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/MyProfileResponse.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.controller.handler.auth.dto
+package com.kroffle.knitting.controller.handler.knitter.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 data class SalesSummaryResponse(
-    @JsonProperty("number_of_designs_on_sales")
-    val numberOfDesignsOnSales: Int,
-    @JsonProperty("number_of_designs_sold")
-    val numberOfDesignsSold: Int,
+    @JsonProperty("number_of_products_on_sales")
+    val numberOfProductsOnSales: Int,
+    @JsonProperty("number_of_products_sold")
+    val numberOfProductsSold: Int,
 ) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.controller.handler.design.dto
+package com.kroffle.knitting.controller.handler.knitter.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -15,7 +15,6 @@ class DesignsRouter(private val handler: DesignHandler) {
         router {
             listOf(
                 GET(GET_MY_DESIGNS_PATH, handler::getMyDesigns),
-                GET(GET_MY_SALES_SUMMARY_PATH, handler::getMySalesSummary),
             )
         }
     )
@@ -23,7 +22,6 @@ class DesignsRouter(private val handler: DesignHandler) {
     companion object {
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/my"
-        private const val GET_MY_SALES_SUMMARY_PATH = "/sales-summary/my"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouter.kt
@@ -1,6 +1,6 @@
-package com.kroffle.knitting.controller.router.auth
+package com.kroffle.knitting.controller.router.knitter
 
-import com.kroffle.knitting.controller.handler.auth.ProfileHandler
+import com.kroffle.knitting.controller.handler.knitter.MyselfHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RequestPredicates
@@ -8,19 +8,22 @@ import org.springframework.web.reactive.function.server.RouterFunctions
 import org.springframework.web.reactive.function.server.router
 
 @Configuration
-class ProfileRouter(private val handler: ProfileHandler) {
+class MyselfRouter(private val handler: MyselfHandler) {
     @Bean
     fun profileRouterFunction() = RouterFunctions.nest(
         RequestPredicates.path(ROOT_PATH),
         router {
             listOf(
-                GET(handler::getMyProfile),
+                GET(GET_MY_PROFILE_PATH, handler::getMyProfile),
+                GET(GET_MY_SALES_SUMMARY_PATH, handler::getMySalesSummary),
             )
         }
     )
 
     companion object {
-        private const val ROOT_PATH = "/profile"
+        private const val ROOT_PATH = "/me"
+        private const val GET_MY_PROFILE_PATH = "/profile"
+        private const val GET_MY_SALES_SUMMARY_PATH = "/sales-summary"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -4,6 +4,7 @@ import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.domain.product.enum.SalesStatus
 import com.kroffle.knitting.domain.product.exception.InvalidDiscountPrice
 import com.kroffle.knitting.domain.product.exception.InvalidFullPrice
+import com.kroffle.knitting.domain.product.exception.InvalidInputStatus
 import com.kroffle.knitting.domain.product.exception.InvalidPeriod
 import com.kroffle.knitting.domain.product.exception.UnableToRegister
 import com.kroffle.knitting.domain.product.value.ProductItem
@@ -45,6 +46,10 @@ class Product(
 
         require(fullPrice > Money.ZERO) {
             throw InvalidFullPrice()
+        }
+
+        require(inputStatus == InputStatus.DRAFT || content != null) {
+            throw InvalidInputStatus()
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidInputStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidInputStatus.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.domain.product.exception
+
+import com.kroffle.knitting.domain.exception.DomainException
+
+class InvalidInputStatus : DomainException("registered product must have content")

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -5,14 +5,11 @@ import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
 import com.kroffle.knitting.infra.oauth.dto.ClientInfo
 import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
-import com.kroffle.knitting.infra.persistence.knitter.repository.DBKnitterRepository
-import com.kroffle.knitting.infra.persistence.knitter.repository.R2dbcKnitterRepository
 import com.kroffle.knitting.infra.properties.AuthProperties
 import com.kroffle.knitting.infra.properties.ClientProperties
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
-import com.kroffle.knitting.usecase.design.DesignService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -5,8 +5,6 @@ import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.oauth.GoogleOAuthHelperImpl
 import com.kroffle.knitting.infra.oauth.dto.ClientInfo
 import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
-import com.kroffle.knitting.infra.persistence.design.repository.DBDesignRepository
-import com.kroffle.knitting.infra.persistence.design.repository.R2dbcDesignRepository
 import com.kroffle.knitting.infra.persistence.knitter.repository.DBKnitterRepository
 import com.kroffle.knitting.infra.persistence.knitter.repository.R2dbcKnitterRepository
 import com.kroffle.knitting.infra.properties.AuthProperties
@@ -38,15 +36,6 @@ class AppConfig {
 
     @Bean
     fun tokenPublisher() = TokenPublisher(authProperties.jwtSecretKey)
-
-    @Bean
-    fun designRepository(dbDesignRepository: DBDesignRepository) = R2dbcDesignRepository(dbDesignRepository)
-
-    @Bean
-    fun designService(repository: DesignService.DesignRepository) = DesignService(repository)
-
-    @Bean
-    fun userRepository(dbKnitterRepository: DBKnitterRepository) = R2dbcKnitterRepository(dbKnitterRepository)
 
     @Bean
     fun authService(repository: AuthService.KnitterRepository) = AuthService(

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
@@ -4,7 +4,7 @@ import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.persistence.design.entity.toDesignEntity
 import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
-import com.kroffle.knitting.usecase.design.DesignRepository
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
@@ -4,10 +4,10 @@ import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.persistence.design.entity.toDesignEntity
 import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
-import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
@@ -8,9 +8,11 @@ import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
+@Component
 class R2dbcDesignRepository(private val repository: DBDesignRepository) : DesignRepository {
     override fun createDesign(design: Design): Mono<Design> =
         repository

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2dbcKnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2dbcKnitterRepository.kt
@@ -2,7 +2,7 @@ package com.kroffle.knitting.infra.persistence.knitter.repository
 
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.infra.persistence.knitter.entity.toKnitterEntity
-import com.kroffle.knitting.usecase.auth.KnitterRepository
+import com.kroffle.knitting.usecase.repository.KnitterRepository
 import reactor.core.publisher.Mono
 
 class R2dbcKnitterRepository(private val repository: DBKnitterRepository) : KnitterRepository {

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2dbcKnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2dbcKnitterRepository.kt
@@ -3,8 +3,10 @@ package com.kroffle.knitting.infra.persistence.knitter.repository
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.infra.persistence.knitter.entity.toKnitterEntity
 import com.kroffle.knitting.usecase.repository.KnitterRepository
+import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
 
+@Component
 class R2dbcKnitterRepository(private val repository: DBKnitterRepository) : KnitterRepository {
     override fun create(user: Knitter): Mono<Knitter> = repository
         .save(user.toKnitterEntity())

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
@@ -16,6 +16,7 @@ class ProductItemEntity(
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
     fun toItem() = ProductItem.create(id, itemId, createdAt, type)
+    fun getForeignKey(): Long = productId
 }
 
 fun Product.toProductItemEntities(productId: Long): List<ProductItemEntity> =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
@@ -18,6 +18,7 @@ class ProductTagEntity(
         tag = tag,
         createdAt = createdAt,
     )
+    fun getForeignKey(): Long = productId
 }
 
 fun Product.toProductTagEntities(productId: Long): List<ProductTagEntity> =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
@@ -6,4 +6,5 @@ import reactor.core.publisher.Flux
 
 interface DBProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductItemEntity>
+    fun findAllByProductIdIn(productId: List<Long>): Flux<ProductItemEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
@@ -1,6 +1,10 @@
 package com.kroffle.knitting.infra.persistence.product.repository
 
+import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
 
-interface DBProductRepository : ReactiveCrudRepository<ProductEntity, Long>
+interface DBProductRepository : ReactiveCrudRepository<ProductEntity, Long> {
+    fun findAllByKnitterIdAndInputStatus(knitterId: Long, inputStatus: InputStatus): Flux<ProductEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
@@ -6,4 +6,5 @@ import reactor.core.publisher.Flux
 
 interface DBProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductTagEntity>
+    fun findAllByProductIdIn(productId: List<Long>): Flux<ProductTagEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -6,7 +6,7 @@ import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductItemEntities
 import com.kroffle.knitting.infra.persistence.product.entity.toProductTagEntities
-import com.kroffle.knitting.usecase.product.ProductRepository
+import com.kroffle.knitting.usecase.repository.ProductRepository
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -1,8 +1,11 @@
 package com.kroffle.knitting.infra.persistence.product.repository
 
 import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
+import com.kroffle.knitting.infra.persistence.product.entity.ProductItemEntity
+import com.kroffle.knitting.infra.persistence.product.entity.ProductTagEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductItemEntities
 import com.kroffle.knitting.infra.persistence.product.entity.toProductTagEntities
@@ -69,6 +72,42 @@ class R2dbcProductRepository(
             .switchIfEmpty(Mono.error(NotFoundEntity(ProductEntity::class.java)))
 
     override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
-        TODO("Not yet implemented")
+        val products: Flux<ProductEntity> =
+            productRepository
+                .findAllByKnitterIdAndInputStatus(knitterId, InputStatus.REGISTERED)
+
+        val productIds: Mono<List<Long>> =
+            products
+                .map {
+                    it.getNotNullId()
+                }
+                .collect(toList())
+
+        val tagMap: Mono<Map<Long, Collection<ProductTagEntity>>> =
+            productIds
+                .flatMap {
+                    productTagRepository
+                        .findAllByProductIdIn(it)
+                        .collectMultimap { tag -> tag.getForeignKey() }
+                }
+        val itemMap: Mono<Map<Long, Collection<ProductItemEntity>>> =
+            productIds
+                .flatMap {
+                    productItemRepository
+                        .findAllByProductIdIn(it)
+                        .collectMultimap { item -> item.getForeignKey() }
+                }
+        return products
+            .flatMap {
+                product ->
+                Mono.zip(tagMap, itemMap)
+                    .map {
+                        val productId = product.getNotNullId()
+                        product.toProduct(
+                            it.t1[productId]?.map { tag -> tag.toTag() } ?: listOf(),
+                            it.t2[productId]?.map { item -> item.toItem() } ?: listOf()
+                        )
+                    }
+            }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -8,6 +8,7 @@ import com.kroffle.knitting.infra.persistence.product.entity.toProductItemEntiti
 import com.kroffle.knitting.infra.persistence.product.entity.toProductTagEntities
 import com.kroffle.knitting.usecase.repository.ProductRepository
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList
 
@@ -66,4 +67,8 @@ class R2dbcProductRepository(
                 it.knitterId == knitterId
             }
             .switchIfEmpty(Mono.error(NotFoundEntity(ProductEntity::class.java)))
+
+    override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -41,9 +41,6 @@ class AuthService(
         return tokenPublisher.publish(knitterId)
     }
 
-    fun getKnitter(knitterId: Long): Mono<Knitter> =
-        knitterRepository.findById(knitterId)
-
     interface OAuthHelper {
         fun getAuthorizationUri(): URI
         fun getProfile(code: String): Mono<OAuthProfile>
@@ -56,6 +53,5 @@ class AuthService(
     interface KnitterRepository {
         fun create(user: Knitter): Mono<Knitter>
         fun findByEmail(email: String): Mono<Knitter>
-        fun findById(id: Long): Mono<Knitter>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/KnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/KnitterRepository.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.usecase.auth
-
-interface KnitterRepository : AuthService.KnitterRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignRepository.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.usecase.design
-
-interface DesignRepository : DesignService.DesignRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -4,9 +4,11 @@ import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
+@Component
 class DesignService(private val repository: DesignRepository) {
     fun create(design: Design): Mono<Design> = repository.createDesign(design)
 

--- a/src/main/kotlin/com/kroffle/knitting/usecase/knitter/KnitterService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/knitter/KnitterService.kt
@@ -1,0 +1,15 @@
+package com.kroffle.knitting.usecase.knitter
+
+import com.kroffle.knitting.domain.knitter.entity.Knitter
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class KnitterService(private val knitterRepository: KnitterRepository) {
+    fun getKnitter(knitterId: Long): Mono<Knitter> =
+        knitterRepository.findById(knitterId)
+
+    interface KnitterRepository {
+        fun findById(id: Long): Mono<Knitter>
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductRepository.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.usecase.product
-
-interface ProductRepository : ProductService.ProductRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/DesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/DesignRepository.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.usecase.repository
+
+import com.kroffle.knitting.usecase.design.DesignService
+
+interface DesignRepository : DesignService.DesignRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/KnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/KnitterRepository.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.usecase.repository
+
+import com.kroffle.knitting.usecase.auth.AuthService
+import com.kroffle.knitting.usecase.knitter.KnitterService
+
+interface KnitterRepository
+    : AuthService.KnitterRepository, KnitterService.KnitterRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/KnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/KnitterRepository.kt
@@ -3,5 +3,5 @@ package com.kroffle.knitting.usecase.repository
 import com.kroffle.knitting.usecase.auth.AuthService
 import com.kroffle.knitting.usecase.knitter.KnitterService
 
-interface KnitterRepository
-    : AuthService.KnitterRepository, KnitterService.KnitterRepository
+interface KnitterRepository :
+    AuthService.KnitterRepository, KnitterService.KnitterRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/ProductRepository.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.usecase.repository
+
+import com.kroffle.knitting.usecase.product.ProductService
+
+interface ProductRepository : ProductService.ProductRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/ProductRepository.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.usecase.repository
 
 import com.kroffle.knitting.usecase.product.ProductService
+import com.kroffle.knitting.usecase.summary.ProductSummaryService
 
-interface ProductRepository : ProductService.ProductRepository
+interface ProductRepository : ProductService.ProductRepository, ProductSummaryService.ProductRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
@@ -10,7 +10,7 @@ class ProductSummaryService(private val repository: ProductRepository) {
     fun countProductOnList(knitterId: Long): Mono<Long> =
         repository
             .findRegisteredProduct(knitterId)
-            .filter{ it.onList }
+            .filter { it.onList }
             .count()
 
     interface ProductRepository {

--- a/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
@@ -1,0 +1,19 @@
+package com.kroffle.knitting.usecase.summary
+
+import com.kroffle.knitting.domain.product.entity.Product
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@Component
+class ProductSummaryService(private val repository: ProductRepository) {
+    fun countProductOnList(knitterId: Long): Mono<Long> =
+        repository
+            .findRegisteredProduct(knitterId)
+            .filter{ it.onList }
+            .count()
+
+    interface ProductRepository {
+        fun findRegisteredProduct(knitterId: Long): Flux<Product>
+    }
+}

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -15,7 +15,7 @@ import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
 import com.kroffle.knitting.infra.persistence.knitter.entity.KnitterEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
-import com.kroffle.knitting.usecase.auth.KnitterRepository
+import com.kroffle.knitting.usecase.repository.KnitterRepository
 import com.kroffle.knitting.usecase.auth.dto.OAuthProfile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -15,8 +15,8 @@ import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
 import com.kroffle.knitting.infra.persistence.knitter.entity.KnitterEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
-import com.kroffle.knitting.usecase.repository.KnitterRepository
 import com.kroffle.knitting.usecase.auth.dto.OAuthProfile
+import com.kroffle.knitting.usecase.repository.KnitterRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -15,8 +15,8 @@ import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -15,7 +15,7 @@ import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.design.DesignRepository
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -12,7 +12,7 @@ import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.design.DesignRepository
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -12,9 +12,9 @@ import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+import com.kroffle.knitting.usecase.repository.DesignRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -2,7 +2,6 @@ package com.kroffle.knitting.controller.router.design
 
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
-import com.kroffle.knitting.controller.handler.design.dto.SalesSummaryResponse
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.LevelType
 import com.kroffle.knitting.domain.design.enum.PatternType
@@ -124,27 +123,6 @@ class DesignsRouterTest {
                 assert(param.direction == SortDirection.DESC)
                 true
             },
-        )
-    }
-
-    @Test
-    fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
-        val responseBody: TestResponse<SalesSummaryResponse> = webClient
-            .get()
-            .uri("/designs/sales-summary/my")
-            .addDefaultRequestHeader()
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody<TestResponse<SalesSummaryResponse>>()
-            .returnResult()
-            .responseBody!!
-
-        assertThat(responseBody.payload).isEqualTo(
-            SalesSummaryResponse(
-                numberOfDesignsOnSales = 1,
-                numberOfDesignsSold = 2,
-            ),
         )
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.controller.router.knitter
 import com.kroffle.knitting.controller.handler.knitter.MyselfHandler
 import com.kroffle.knitting.controller.handler.knitter.dto.MyProfileResponse
 import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummaryResponse
+import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
 import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
@@ -11,7 +12,8 @@ import com.kroffle.knitting.infra.jwt.TokenPublisher
 import com.kroffle.knitting.infra.persistence.knitter.entity.KnitterEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
-import com.kroffle.knitting.usecase.auth.KnitterRepository
+import com.kroffle.knitting.usecase.knitter.KnitterService
+import com.kroffle.knitting.usecase.repository.KnitterRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,15 +50,8 @@ class MyselfRouterTest {
     fun setUp() {
         webClient = WebTestClientHelper
             .createWebTestClient(
-                MyselfRouter(
-                    MyselfHandler(
-                        AuthService(
-                            mockOAuthHelper,
-                            tokenPublisher,
-                            repository,
-                        ),
-                    )
-                ).profileRouterFunction()
+                MyselfRouter(MyselfHandler(KnitterService(repository)))
+                    .profileRouterFunction()
             )
     }
 

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
@@ -3,9 +3,11 @@ package com.kroffle.knitting.controller.router.knitter
 import com.kroffle.knitting.controller.handler.knitter.MyselfHandler
 import com.kroffle.knitting.controller.handler.knitter.dto.MyProfileResponse
 import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummaryResponse
-import com.kroffle.knitting.domain.knitter.entity.Knitter
+import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
+import com.kroffle.knitting.helper.dto.MockProductData
 import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.jwt.TokenPublisher
@@ -14,17 +16,23 @@ import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
 import com.kroffle.knitting.usecase.knitter.KnitterService
 import com.kroffle.knitting.usecase.repository.KnitterRepository
+import com.kroffle.knitting.usecase.repository.ProductRepository
+import com.kroffle.knitting.usecase.summary.ProductSummaryService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.LocalDateTime
 
 @WebFluxTest
 @ExtendWith(SpringExtension::class)
@@ -32,7 +40,10 @@ class MyselfRouterTest {
     private lateinit var webClient: WebTestClient
 
     @MockBean
-    private lateinit var repository: KnitterRepository
+    private lateinit var knitterRepository: KnitterRepository
+
+    @MockBean
+    private lateinit var productRepository: ProductRepository
 
     @MockBean
     private lateinit var mockOAuthHelper: AuthService.OAuthHelper
@@ -50,14 +61,20 @@ class MyselfRouterTest {
     fun setUp() {
         webClient = WebTestClientHelper
             .createWebTestClient(
-                MyselfRouter(MyselfHandler(KnitterService(repository)))
+                MyselfRouter(
+                    MyselfHandler(
+                        KnitterService(knitterRepository),
+                        ProductSummaryService(productRepository),
+                    ),
+
+                )
                     .profileRouterFunction()
             )
     }
 
     @Test
     fun `내 프로필을 조회할 수 있어야 함`() {
-        given(repository.findById(WebTestClientHelper.AUTHORIZED_KNITTER_ID))
+        given(knitterRepository.findById(WebTestClientHelper.AUTHORIZED_KNITTER_ID))
             .willReturn(
                 Mono.just(
                     KnitterEntity(
@@ -90,6 +107,34 @@ class MyselfRouterTest {
 
     @Test
     fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
+        val yesterday = LocalDateTime.now().minusDays(1).toLocalDate()
+        val productsToBeCounted = Flux.just(
+            MockFactory.create(MockProductData(id=1, content = "이 상품은요", inputStatus = InputStatus.REGISTERED)),
+            MockFactory.create(
+                MockProductData(
+                    id=2,
+                    content = "이 상품은요",
+                    inputStatus = InputStatus.REGISTERED,
+                    specifiedSalesStartDate = yesterday,
+                )
+            ),
+        )
+        val productsToBeSkipped = Flux.just(
+            MockFactory.create(MockProductData(id=3, inputStatus = InputStatus.DRAFT)),
+            MockFactory.create(MockProductData(id=4, content="이 상품은요", inputStatus = InputStatus.DRAFT)),
+            MockFactory.create(
+                MockProductData(
+                    id=5,
+                    content = "이 상품은요",
+                    inputStatus = InputStatus.REGISTERED,
+                    specifiedSalesEndDate = yesterday,
+                )
+            ),
+
+        )
+        given(productRepository.findRegisteredProduct(any()))
+            .willReturn(productsToBeCounted.concatWith(productsToBeSkipped))
+
         val responseBody: TestResponse<SalesSummaryResponse> = webClient
             .get()
             .uri("/me/sales-summary")
@@ -103,9 +148,11 @@ class MyselfRouterTest {
 
         assertThat(responseBody.payload).isEqualTo(
             SalesSummaryResponse(
-                numberOfDesignsOnSales = 1,
-                numberOfDesignsSold = 2,
+                numberOfProductsOnSales = 2,
+                numberOfProductsSold = 0,
             ),
         )
+        verify(productRepository)
+            .findRegisteredProduct(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
@@ -109,10 +109,10 @@ class MyselfRouterTest {
     fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
         val yesterday = LocalDateTime.now().minusDays(1).toLocalDate()
         val productsToBeCounted = Flux.just(
-            MockFactory.create(MockProductData(id=1, content = "이 상품은요", inputStatus = InputStatus.REGISTERED)),
+            MockFactory.create(MockProductData(id = 1, content = "이 상품은요", inputStatus = InputStatus.REGISTERED)),
             MockFactory.create(
                 MockProductData(
-                    id=2,
+                    id = 2,
                     content = "이 상품은요",
                     inputStatus = InputStatus.REGISTERED,
                     specifiedSalesStartDate = yesterday,
@@ -120,11 +120,11 @@ class MyselfRouterTest {
             ),
         )
         val productsToBeSkipped = Flux.just(
-            MockFactory.create(MockProductData(id=3, inputStatus = InputStatus.DRAFT)),
-            MockFactory.create(MockProductData(id=4, content="이 상품은요", inputStatus = InputStatus.DRAFT)),
+            MockFactory.create(MockProductData(id = 3, inputStatus = InputStatus.DRAFT)),
+            MockFactory.create(MockProductData(id = 4, content = "이 상품은요", inputStatus = InputStatus.DRAFT)),
             MockFactory.create(
                 MockProductData(
-                    id=5,
+                    id = 5,
                     content = "이 상품은요",
                     inputStatus = InputStatus.REGISTERED,
                     specifiedSalesEndDate = yesterday,

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -20,7 +20,7 @@ import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
 import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.product.ProductRepository
+import com.kroffle.knitting.usecase.repository.ProductRepository
 import com.kroffle.knitting.usecase.product.ProductService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -20,8 +20,8 @@ import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
 import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import com.kroffle.knitting.usecase.repository.ProductRepository
 import com.kroffle.knitting.usecase.product.ProductService
+import com.kroffle.knitting.usecase.repository.ProductRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
@@ -1,0 +1,26 @@
+package com.kroffle.knitting.helper
+
+import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.helper.dto.MockProductData
+
+class MockFactory {
+    companion object {
+        fun create(data: MockProductData): Product {
+            return Product(
+                id = data.id,
+                knitterId = data.knitterId,
+                name = data.name,
+                fullPrice = data.fullPrice,
+                discountPrice = data.discountPrice,
+                representativeImageUrl = data.representativeImageUrl,
+                specifiedSalesStartDate = data.specifiedSalesStartDate,
+                specifiedSalesEndDate = data.specifiedSalesEndDate,
+                tags = data.tags,
+                content = data.content,
+                inputStatus = data.inputStatus,
+                items = data.items,
+                createdAt = data.createdAt,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
@@ -1,0 +1,25 @@
+package com.kroffle.knitting.helper.dto
+
+import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.value.ProductItem
+import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
+import com.kroffle.knitting.helper.WebTestClientHelper
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class MockProductData(
+    val id: Long,
+    val knitterId: Long = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
+    val name: String = "상품 이름",
+    val fullPrice: Money = Money(10000),
+    val discountPrice: Money = Money(100),
+    val representativeImageUrl: String = "http://test.knitting.com/image.jpg",
+    val specifiedSalesStartDate: LocalDate? = null,
+    val specifiedSalesEndDate: LocalDate? = null,
+    val tags: List<ProductTag> = listOf(),
+    val content: String? = null,
+    val inputStatus: InputStatus = InputStatus.DRAFT,
+    val items: List<ProductItem> = listOf(),
+    val createdAt: LocalDateTime? = LocalDateTime.now(),
+)

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
@@ -5,14 +5,14 @@ import com.kroffle.knitting.domain.product.entity.Product
 fun Product.like(other: Product): Boolean {
     if (this === other) return true
     tags.mapIndexed {
-        idx, tag ->
-        if (other.tags[idx].tag != tag.tag) {
+        index, tag ->
+        if (other.tags[index].tag != tag.tag) {
             return false
         }
     }
     items.mapIndexed {
-        idx, item ->
-        if (other.items[idx].itemId != item.itemId) {
+        index, item ->
+        if (other.items[index].itemId != item.itemId) {
             return false
         }
     }


### PR DESCRIPTION
## PR 제안 사유
- 내 프로필에서 현재 판매중인 상품의 수를 조회할 수 있도록 구현합니다.

Resolves #91 

## 주요 변경 기록
- profile api와 sales-summary 위치 변경
  - profile은 auth아래에 있는게 어색하고, sales-summary는 design아래에 있는 것이 어색하여 옮깁니다.
  - 사용자 정보를 조회할 수 있는 knitter 패키지를 만들고 그중 자신을 조회하는 MyselfHandler를 만들었습니다.
- @component 어노테이션을 이용하여 빈을 만들 수 있도록 수정합니다.
- MockData를 쉽게 만들 수 있는 테스트 전용 Helper클래스를 만듭니다. (기본값이 지정되어있어서 필요한 정보만 수정하여 생성할 수 있습니다.)
- sales-summary api를 구현합니다.
