### PR TITLE
상품에 updated_at 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -27,6 +27,7 @@ class Product(
     val inputStatus: InputStatus,
     val items: List<ProductItem>,
     val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
 ) {
     init {
         require(
@@ -87,6 +88,7 @@ class Product(
             inputStatus,
             items,
             createdAt,
+            LocalDateTime.now(),
         )
     }
 
@@ -108,6 +110,7 @@ class Product(
             InputStatus.REGISTERED,
             items,
             createdAt,
+            LocalDateTime.now(),
         )
     }
 
@@ -138,6 +141,7 @@ class Product(
                 InputStatus.DRAFT,
                 items,
                 null,
+                LocalDateTime.now(),
             )
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
@@ -23,6 +23,7 @@ class ProductEntity(
     private val content: String?,
     private val inputStatus: InputStatus,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
+    private val updatedAt: LocalDateTime = LocalDateTime.now(),
 ) {
     fun getNotNullId(): Long = id!!
 
@@ -41,6 +42,7 @@ class ProductEntity(
             tags = tags,
             items = items,
             createdAt = createdAt,
+            updatedAt = updatedAt,
         )
 }
 
@@ -57,4 +59,5 @@ fun Product.toProductEntity() =
         content = content,
         inputStatus = inputStatus,
         createdAt = this.createdAt ?: LocalDateTime.now(),
+        updatedAt = this.updatedAt ?: LocalDateTime.now(),
     )

--- a/src/main/resources/db/migration/V5__add_updated_at_to_product.sql
+++ b/src/main/resources/db/migration/V5__add_updated_at_to_product.sql
@@ -1,0 +1,5 @@
+ALTER TABLE product ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE product SET updated_at = created_at;
+
+ALTER TABLE product ALTER COLUMN updated_at SET NOT NULL;

--- a/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
@@ -20,6 +20,7 @@ class MockFactory {
                 inputStatus = data.inputStatus,
                 items = data.items,
                 createdAt = data.createdAt,
+                updatedAt = data.updatedAt,
             )
         }
     }

--- a/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
@@ -22,4 +22,5 @@ data class MockProductData(
     val inputStatus: InputStatus = InputStatus.DRAFT,
     val items: List<ProductItem> = listOf(),
     val createdAt: LocalDateTime? = LocalDateTime.now(),
+    val updatedAt: LocalDateTime? = LocalDateTime.now(),
 )


### PR DESCRIPTION
## PR 제안 사유
상품에 대한 내용을 작성시 마지막 수정 시간을 트래킹 할 수 있도록 합니다.

Resolves #114 

## 주요 변경 기록
- updated_at 필드 및 컬럼 추가
- 도메인 함수에서 updated_at 업데이트 해줄 수 있도록 수정
- updated_at이 잘 업데이트 되는지 테스트 추가