### PR TITLE
feat: 상품 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -8,6 +8,7 @@ import com.kroffle.knitting.controller.handler.product.dto.DraftProductContentRe
 import com.kroffle.knitting.controller.handler.product.dto.DraftProductContentResponse
 import com.kroffle.knitting.controller.handler.product.dto.DraftProductPackageRequest
 import com.kroffle.knitting.controller.handler.product.dto.DraftProductPackageResponse
+import com.kroffle.knitting.controller.handler.product.dto.GetMyProductResponse
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProductRequest
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProductResponse
 import com.kroffle.knitting.domain.product.entity.Product
@@ -18,6 +19,7 @@ import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.usecase.product.ProductService
 import com.kroffle.knitting.usecase.product.dto.DraftProductContentData
 import com.kroffle.knitting.usecase.product.dto.DraftProductPackageData
+import com.kroffle.knitting.usecase.product.dto.GetMyProductData
 import com.kroffle.knitting.usecase.product.dto.RegisterProductData
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -112,6 +114,42 @@ class ProductHandler(private val productService: ProductService) {
                 ResponseHelper
                     .makeJsonResponse(
                         RegisterProductResponse(it.id!!)
+                    )
+            }
+    }
+
+    fun getMyProduct(req: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(req)
+        val productId = req.pathVariable("id").toLong()
+        val product: Mono<Product> =
+            productService.get(
+                GetMyProductData(
+                    id = productId,
+                    knitterId = knitterId,
+                )
+            )
+        return product
+            .onErrorResume {
+                Mono.error(BadRequest(it.message))
+            }
+            .flatMap {
+                ResponseHelper
+                    .makeJsonResponse(
+                        GetMyProductResponse(
+                            id = it.id!!,
+                            name = it.name,
+                            fullPrice = it.fullPrice.value,
+                            discountPrice = it.discountPrice.value,
+                            representativeImageUrl = it.representativeImageUrl,
+                            specifiedSalesStartDate = it.specifiedSalesStartDate,
+                            specifiedSalesEndDate = it.specifiedSalesEndDate,
+                            tags = it.tags,
+                            content = it.content,
+                            inputStatus = it.inputStatus,
+                            items = it.items,
+                            createdAt = it.createdAt!!,
+                            updatedAt = it.updatedAt!!,
+                        )
                     )
             }
     }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductResponse.kt
@@ -1,0 +1,33 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.value.ProductItem
+import com.kroffle.knitting.domain.product.value.ProductTag
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class GetMyProductResponse(
+    val id: Long,
+    val name: String,
+    @JsonProperty("full_price")
+    val fullPrice: Int,
+    @JsonProperty("discount_price")
+    val discountPrice: Int,
+    @JsonProperty("representative_image_url")
+    val representativeImageUrl: String,
+    @JsonProperty("specified_sales_start_date")
+    val specifiedSalesStartDate: LocalDate?,
+    @JsonProperty("specified_sales_end_date")
+    val specifiedSalesEndDate: LocalDate?,
+    val tags: List<ProductTag>,
+    val content: String?,
+    @JsonProperty("input_status")
+    val inputStatus: InputStatus,
+    val items: List<ProductItem>,
+    @JsonProperty("created_at")
+    val createdAt: LocalDateTime?,
+    @JsonProperty("updated_at")
+    val updatedAt: LocalDateTime?,
+) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
@@ -18,6 +18,7 @@ class ProductRouter(private val handler: ProductHandler) {
                 POST(DRAFT_PRODUCT_PACKAGE_PATH, handler::draftProductPackage),
                 POST(DRAFT_PRODUCT_CONTENT_PATH, handler::draftProductContent),
                 POST(handler::registerProduct),
+                GET(GET_MY_PRODUCT_PATH, handler::getMyProduct),
             )
         }
     )
@@ -26,6 +27,7 @@ class ProductRouter(private val handler: ProductHandler) {
         private const val ROOT_PATH = "/product"
         private const val DRAFT_PRODUCT_PACKAGE_PATH = "/package"
         private const val DRAFT_PRODUCT_CONTENT_PATH = "/content"
+        private const val GET_MY_PRODUCT_PATH = "/mine/{id}"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.usecase.product
 import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.usecase.product.dto.DraftProductContentData
 import com.kroffle.knitting.usecase.product.dto.DraftProductPackageData
+import com.kroffle.knitting.usecase.product.dto.GetMyProductData
 import com.kroffle.knitting.usecase.product.dto.RegisterProductData
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
@@ -42,6 +43,10 @@ class ProductService(private val repository: ProductRepository) {
                     .save(it.register())
             }
     }
+
+    fun get(data: GetMyProductData): Mono<Product> =
+        repository
+            .getProductByIdAndKnitterId(data.id, data.knitterId)
 
     interface ProductRepository {
         fun save(product: Product): Mono<Product>

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/GetMyProductData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/GetMyProductData.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.usecase.product.dto
+
+data class GetMyProductData(
+    val id: Long,
+    val knitterId: Long,
+)

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
@@ -1,0 +1,30 @@
+package com.kroffle.knitting.helper.extension
+
+import com.kroffle.knitting.controller.handler.product.dto.GetMyProductResponse
+
+fun GetMyProductResponse.like(other: GetMyProductResponse): Boolean {
+    if (this === other) return true
+    tags.mapIndexed {
+        index, tag ->
+        if (other.tags[index].tag != tag.tag) {
+            return false
+        }
+    }
+    items.mapIndexed {
+        index, item ->
+        if (other.items[index].itemId != item.itemId) {
+            return false
+        }
+    }
+    return id == other.id &&
+        name == other.name &&
+        fullPrice == other.fullPrice &&
+        discountPrice == other.discountPrice &&
+        representativeImageUrl == other.representativeImageUrl &&
+        specifiedSalesStartDate == other.specifiedSalesStartDate &&
+        specifiedSalesEndDate == other.specifiedSalesEndDate &&
+        content == other.content &&
+        inputStatus == other.inputStatus &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt
+}


### PR DESCRIPTION
## PR 제안 사유
- 내 상품 리스트에서 수정시 다시 상품 정보를 가져올 때 사용할 수 있도록 상품 조회 API를 구현합니다.

Resolves #112

## 주요 변경 기록
- 상품 조회 API 구현

## API Spec

https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-1b1b9b22-dbc7-4bc5-a217-9959269359ae