### PR TITLE
feat: 내가 만든 상품 리스트 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -12,8 +12,8 @@ class PaginationHelper {
             else value.get()
         }
 
-        private fun getAfter(request: ServerRequest): Long? {
-            return getValue(request, "after")?.toLong()
+        private fun getAfter(request: ServerRequest): String? {
+            return getValue(request, "after")
         }
 
         private fun getCount(request: ServerRequest): Int {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -86,10 +86,7 @@ class ProductHandler(private val productService: ProductService) {
         }
 
         return product
-            .onErrorResume {
-                error ->
-                Mono.error(BadRequest(error.message))
-            }
+            .onErrorResume { Mono.error(BadRequest(it.message)) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -114,9 +111,7 @@ class ProductHandler(private val productService: ProductService) {
             )
         }
         return product
-            .onErrorResume {
-                Mono.error(BadRequest(it.message))
-            }
+            .onErrorResume { Mono.error(BadRequest(it.message)) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -136,9 +131,7 @@ class ProductHandler(private val productService: ProductService) {
                 )
             )
         return product
-            .onErrorResume {
-                Mono.error(BadRequest(it.message))
-            }
+            .onErrorResume { Mono.error(BadRequest(it.message)) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -175,9 +168,7 @@ class ProductHandler(private val productService: ProductService) {
                 )
 
         return products
-            .onErrorResume {
-                Mono.error(BadRequest(it.message))
-            }
+            .onErrorResume { Mono.error(BadRequest(it.message)) }
             .map {
                 product ->
                 GetMyProductsResponse(
@@ -194,8 +185,6 @@ class ProductHandler(private val productService: ProductService) {
                 )
             }
             .collect(toList())
-            .flatMap {
-                ResponseHelper.makeJsonResponse(it)
-            }
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -143,10 +143,10 @@ class ProductHandler(private val productService: ProductService) {
                             representativeImageUrl = it.representativeImageUrl,
                             specifiedSalesStartDate = it.specifiedSalesStartDate,
                             specifiedSalesEndDate = it.specifiedSalesEndDate,
-                            tags = it.tags,
+                            tags = it.tags.map { tag -> tag.tag },
                             content = it.content,
                             inputStatus = it.inputStatus,
-                            items = it.items,
+                            itemIds = it.items.map { item -> item.itemId },
                             createdAt = it.createdAt!!,
                             updatedAt = it.updatedAt!!,
                         )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -143,7 +143,7 @@ class ProductHandler(private val productService: ProductService) {
                             representativeImageUrl = it.representativeImageUrl,
                             specifiedSalesStartDate = it.specifiedSalesStartDate,
                             specifiedSalesEndDate = it.specifiedSalesEndDate,
-                            tags = it.tags.map { tag -> tag.tag },
+                            tags = it.tags.map { tag -> tag.name },
                             content = it.content,
                             inputStatus = it.inputStatus,
                             itemIds = it.items.map { item -> item.itemId },
@@ -179,7 +179,7 @@ class ProductHandler(private val productService: ProductService) {
                     representativeImageUrl = product.representativeImageUrl,
                     specifiedSalesStartDate = product.specifiedSalesStartDate,
                     specifiedSalesEndDate = product.specifiedSalesEndDate,
-                    tags = product.tags.map { it.tag },
+                    tags = product.tags.map { it.name },
                     inputStatus = product.inputStatus,
                     updatedAt = product.updatedAt,
                 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductResponse.kt
@@ -3,8 +3,6 @@ package com.kroffle.knitting.controller.handler.product.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import com.kroffle.knitting.domain.product.enum.InputStatus
-import com.kroffle.knitting.domain.product.value.ProductItem
-import com.kroffle.knitting.domain.product.value.ProductTag
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -21,11 +19,11 @@ data class GetMyProductResponse(
     val specifiedSalesStartDate: LocalDate?,
     @JsonProperty("specified_sales_end_date")
     val specifiedSalesEndDate: LocalDate?,
-    val tags: List<ProductTag>,
+    val tags: List<String>,
     val content: String?,
     @JsonProperty("input_status")
     val inputStatus: InputStatus,
-    val items: List<ProductItem>,
+    val itemIds: List<Long>,
     @JsonProperty("created_at")
     val createdAt: LocalDateTime?,
     @JsonProperty("updated_at")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductsResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProductsResponse.kt
@@ -1,0 +1,29 @@
+package com.kroffle.knitting.controller.handler.product.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
+import com.kroffle.knitting.domain.product.enum.InputStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class GetMyProductsResponse(
+    val id: Long,
+    val name: String,
+    @JsonProperty("full_price")
+    val fullPrice: Int,
+    @JsonProperty("discount_price")
+    val discountPrice: Int,
+    @JsonProperty("representative_image_url")
+    val representativeImageUrl: String,
+    @JsonProperty("specified_sales_start_date")
+    val specifiedSalesStartDate: LocalDate?,
+    @JsonProperty("specified_sales_end_date")
+    val specifiedSalesEndDate: LocalDate?,
+    val tags: List<String>,
+    @JsonProperty("input_status")
+    val inputStatus: InputStatus,
+    @JsonProperty("updated_at")
+    val updatedAt: LocalDateTime?,
+) : ListItemPayload {
+    override fun getCursor(): String = updatedAt.toString()
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
@@ -19,6 +19,7 @@ class ProductRouter(private val handler: ProductHandler) {
                 POST(DRAFT_PRODUCT_CONTENT_PATH, handler::draftProductContent),
                 POST(handler::registerProduct),
                 GET(GET_MY_PRODUCT_PATH, handler::getMyProduct),
+                GET(GET_MY_PRODUCTS_PATH, handler::getMyProducts),
             )
         }
     )
@@ -28,6 +29,7 @@ class ProductRouter(private val handler: ProductHandler) {
         private const val DRAFT_PRODUCT_PACKAGE_PATH = "/package"
         private const val DRAFT_PRODUCT_CONTENT_PATH = "/content"
         private const val GET_MY_PRODUCT_PATH = "/mine/{id}"
+        private const val GET_MY_PRODUCTS_PATH = "/mine"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
@@ -5,6 +5,6 @@ import java.time.LocalDateTime
 /* FIXME: #99 이슈 진행하며 id 제거가 가능하다면 제거, 불가능하다면 entity 로 변경합니다. */
 data class ProductTag(
     val id: Long?,
-    val tag: String,
+    val name: String,
     val createdAt: LocalDateTime?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
@@ -28,7 +28,7 @@ class R2dbcDesignRepository(private val repository: DBDesignRepository) : Design
                     repository
                         .findAllByKnitterIdAndIdBefore(
                             knitterId = knitterId,
-                            id = paging.after,
+                            id = paging.after.toLong(),
                             pageable = pageRequest,
                         )
                 } else {

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
@@ -10,12 +10,12 @@ import java.time.LocalDateTime
 class ProductTagEntity(
     @Id private var id: Long? = null,
     private val productId: Long,
-    private val tag: String,
+    private val name: String,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
     fun toTag() = ProductTag(
         id = id,
-        tag = tag,
+        name = name,
         createdAt = createdAt,
     )
     fun getForeignKey(): Long = productId
@@ -27,7 +27,7 @@ fun Product.toProductTagEntities(productId: Long): List<ProductTagEntity> =
         ProductTagEntity(
             id = tag.id,
             productId = this.id ?: productId,
-            tag = tag.tag,
+            name = tag.name,
             createdAt = tag.createdAt ?: LocalDateTime.now(),
         )
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
@@ -2,9 +2,12 @@ package com.kroffle.knitting.infra.persistence.product.repository
 
 import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
 interface DBProductRepository : ReactiveCrudRepository<ProductEntity, Long> {
     fun findAllByKnitterIdAndInputStatus(knitterId: Long, inputStatus: InputStatus): Flux<ProductEntity>
+    fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<ProductEntity>
+    fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<ProductEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -40,9 +40,7 @@ class R2dbcProductRepository(
             .findById(id)
 
         return Mono.zip(product, tags, items)
-            .map {
-                it.t1.toProduct(it.t2, it.t3)
-            }
+            .map { it.t1.toProduct(it.t2, it.t3) }
     }
 
     private fun getProductAggregate(products: Flux<ProductEntity>): Flux<Product> {
@@ -106,9 +104,7 @@ class R2dbcProductRepository(
 
     override fun getProductByIdAndKnitterId(id: Long, knitterId: Long): Mono<Product> =
         findById(id)
-            .filter {
-                it.knitterId == knitterId
-            }
+            .filter { it.knitterId == knitterId }
             .switchIfEmpty(Mono.error(NotFoundEntity(ProductEntity::class.java)))
 
     override fun getProductsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Product> {

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.infra.persistence.product.repository
 import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
+import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
 import com.kroffle.knitting.infra.persistence.product.entity.ProductItemEntity
 import com.kroffle.knitting.infra.persistence.product.entity.ProductTagEntity
@@ -11,6 +12,7 @@ import com.kroffle.knitting.infra.persistence.product.entity.toProductItemEntiti
 import com.kroffle.knitting.infra.persistence.product.entity.toProductTagEntities
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.repository.ProductRepository
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
@@ -40,6 +42,42 @@ class R2dbcProductRepository(
         return Mono.zip(product, tags, items)
             .map {
                 it.t1.toProduct(it.t2, it.t3)
+            }
+    }
+
+    private fun getProductAggregate(products: Flux<ProductEntity>): Flux<Product> {
+        val productIds: Mono<List<Long>> =
+            products
+                .map { product -> product.getNotNullId() }
+                .collect(toList())
+
+        val tagMap: Mono<Map<Long, Collection<ProductTagEntity>>> =
+            productIds
+                .flatMap {
+                    // FIXME: 여러번 호출되는 이유 파악하여 고치기
+                    productTagRepository
+                        .findAllByProductIdIn(it)
+                        .collectMultimap { tag -> tag.getForeignKey() }
+                }
+        val itemMap: Mono<Map<Long, Collection<ProductItemEntity>>> =
+            productIds
+                .flatMap {
+                    productItemRepository
+                        .findAllByProductIdIn(it)
+                        .collectMultimap { item -> item.getForeignKey() }
+                }
+
+        return products
+            .concatMap {
+                product ->
+                Mono.zip(tagMap, itemMap)
+                    .map {
+                        val productId = product.getNotNullId()
+                        product.toProduct(
+                            it.t1[productId]?.map { tag -> tag.toTag() } ?: listOf(),
+                            it.t2[productId]?.map { item -> item.toItem() } ?: listOf()
+                        )
+                    }
             }
     }
 
@@ -74,46 +112,33 @@ class R2dbcProductRepository(
             .switchIfEmpty(Mono.error(NotFoundEntity(ProductEntity::class.java)))
 
     override fun getProductsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Product> {
-        TODO("Not yet implemented")
+        val pageRequest = PaginationHelper.makePageRequest(paging, sort)
+
+        val products: Flux<ProductEntity> = when (sort.direction) {
+            SortDirection.DESC ->
+                if (paging.after != null) {
+                    productRepository
+                        .findAllByKnitterIdAndIdBefore(
+                            knitterId = knitterId,
+                            id = paging.after.toLong(),
+                            pageable = pageRequest,
+                        )
+                } else {
+                    productRepository
+                        .findAllByKnitterId(
+                            knitterId = knitterId,
+                            pageable = pageRequest,
+                        )
+                }
+            else -> throw NotImplementedError()
+        }
+        return getProductAggregate(products)
     }
 
     override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
         val products: Flux<ProductEntity> =
             productRepository
                 .findAllByKnitterIdAndInputStatus(knitterId, InputStatus.REGISTERED)
-
-        val productIds: Mono<List<Long>> =
-            products
-                .map {
-                    it.getNotNullId()
-                }
-                .collect(toList())
-
-        val tagMap: Mono<Map<Long, Collection<ProductTagEntity>>> =
-            productIds
-                .flatMap {
-                    productTagRepository
-                        .findAllByProductIdIn(it)
-                        .collectMultimap { tag -> tag.getForeignKey() }
-                }
-        val itemMap: Mono<Map<Long, Collection<ProductItemEntity>>> =
-            productIds
-                .flatMap {
-                    productItemRepository
-                        .findAllByProductIdIn(it)
-                        .collectMultimap { item -> item.getForeignKey() }
-                }
-        return products
-            .flatMap {
-                product ->
-                Mono.zip(tagMap, itemMap)
-                    .map {
-                        val productId = product.getNotNullId()
-                        product.toProduct(
-                            it.t1[productId]?.map { tag -> tag.toTag() } ?: listOf(),
-                            it.t2[productId]?.map { item -> item.toItem() } ?: listOf()
-                        )
-                    }
-            }
+        return getProductAggregate(products)
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -9,6 +9,8 @@ import com.kroffle.knitting.infra.persistence.product.entity.ProductTagEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductEntity
 import com.kroffle.knitting.infra.persistence.product.entity.toProductItemEntities
 import com.kroffle.knitting.infra.persistence.product.entity.toProductTagEntities
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.repository.ProductRepository
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
@@ -70,6 +72,10 @@ class R2dbcProductRepository(
                 it.knitterId == knitterId
             }
             .switchIfEmpty(Mono.error(NotFoundEntity(ProductEntity::class.java)))
+
+    override fun getProductsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Product> {
+        TODO("Not yet implemented")
+    }
 
     override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
         val products: Flux<ProductEntity> =

--- a/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/helper/pagination/type/Paging.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.usecase.helper.pagination.type
 import java.lang.IllegalArgumentException
 
 class Paging(
-    val after: Long?,
+    val after: String?,
     val count: Int,
 ) {
     init {

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -1,11 +1,15 @@
 package com.kroffle.knitting.usecase.product
 
 import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.product.dto.DraftProductContentData
 import com.kroffle.knitting.usecase.product.dto.DraftProductPackageData
 import com.kroffle.knitting.usecase.product.dto.GetMyProductData
+import com.kroffle.knitting.usecase.product.dto.GetMyProductsData
 import com.kroffle.knitting.usecase.product.dto.RegisterProductData
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Component
@@ -48,8 +52,13 @@ class ProductService(private val repository: ProductRepository) {
         repository
             .getProductByIdAndKnitterId(data.id, data.knitterId)
 
+    fun get(data: GetMyProductsData): Flux<Product> =
+        repository
+            .getProductsByKnitterId(data.knitterId, data.paging, data.sort)
+
     interface ProductRepository {
         fun save(product: Product): Mono<Product>
         fun getProductByIdAndKnitterId(id: Long, knitterId: Long): Mono<Product>
+        fun getProductsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Product>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -33,19 +33,13 @@ class ProductService(private val repository: ProductRepository) {
     fun draft(data: DraftProductContentData): Mono<Product> {
         return repository
             .getProductByIdAndKnitterId(data.id, data.knitterId)
-            .flatMap {
-                repository
-                    .save(it.draftContent(data.content))
-            }
+            .flatMap { repository.save(it.draftContent(data.content)) }
     }
 
     fun register(data: RegisterProductData): Mono<Product> {
         return repository
             .getProductByIdAndKnitterId(data.id, data.knitterId)
-            .flatMap {
-                repository
-                    .save(it.register())
-            }
+            .flatMap { repository.save(it.register()) }
     }
 
     fun get(data: GetMyProductData): Mono<Product> =

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/GetMyProductsData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/GetMyProductsData.kt
@@ -1,0 +1,10 @@
+package com.kroffle.knitting.usecase.product.dto
+
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+
+data class GetMyProductsData(
+    val knitterId: Long,
+    val paging: Paging,
+    val sort: Sort,
+)

--- a/src/main/resources/db/migration/V6__rename_column.sql
+++ b/src/main/resources/db/migration/V6__rename_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE product_tag RENAME COLUMN tag TO name;

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -110,7 +110,7 @@ class DesignsRouterTest {
             )
         )
         verify(repository).getDesignsByKnitterId(
-            argThat { param -> param == 1.toLong() },
+            argThat { param -> param == WebTestClientHelper.AUTHORIZED_KNITTER_ID },
             argThat {
                 param ->
                 assert(param.after == null)

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -125,4 +125,41 @@ class DesignsRouterTest {
             },
         )
     }
+
+    @Test
+    fun `내가 만든 도안 리스트를 더 불러올 때 페이지네이션 정보가 적절히 넘어가야 함`() {
+        given(repository.getDesignsByKnitterId(any(), any(), any()))
+            .willReturn(Flux.empty())
+
+        webClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/designs/my")
+                    .queryParam("count", "2")
+                    .queryParam("after", "1")
+                    .build()
+            }
+            .addDefaultRequestHeader()
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody<TestResponse<List<MyDesign>>>()
+            .returnResult()
+            .responseBody!!
+
+        verify(repository).getDesignsByKnitterId(
+            argThat { param -> param == WebTestClientHelper.AUTHORIZED_KNITTER_ID },
+            argThat { param ->
+                assert(param.after == "1")
+                assert(param.count == 2)
+                true
+            },
+            argThat { param ->
+                assert(param.column == "id")
+                assert(param.direction == SortDirection.DESC)
+                true
+            },
+        )
+    }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -395,4 +395,41 @@ class ProductRouterTest {
             },
         )
     }
+
+    @Test
+    fun `내 상품 리스트를 더 불러올 때 페이지네이션 정보가 적절히 넘어가야 함`() {
+        given(repository.getProductsByKnitterId(any(), any(), any()))
+            .willReturn(Flux.empty())
+
+        webClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/product/mine")
+                    .queryParam("count", "2")
+                    .queryParam("after", "1")
+                    .build()
+            }
+            .addDefaultRequestHeader()
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody<TestResponse<List<GetMyProductsResponse>>>()
+            .returnResult()
+            .responseBody!!
+
+        verify(repository).getProductsByKnitterId(
+            argThat { param -> param == WebTestClientHelper.AUTHORIZED_KNITTER_ID },
+            argThat { param ->
+                assert(param.after == "1")
+                assert(param.count == 2)
+                true
+            },
+            argThat { param ->
+                assert(param.column == "id")
+                assert(param.direction == SortDirection.DESC)
+                true
+            },
+        )
+    }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -145,7 +145,7 @@ class ProductRouterTest {
                 )
                 product.tags.mapIndexed {
                     index, tag ->
-                    assert(createdProduct.tags[index].tag == tag.tag)
+                    assert(createdProduct.tags[index].name == tag.name)
                 }
                 product.items.mapIndexed {
                     index, item ->
@@ -317,7 +317,7 @@ class ProductRouterTest {
                         representativeImageUrl = mockData.representativeImageUrl,
                         specifiedSalesStartDate = mockData.specifiedSalesStartDate,
                         specifiedSalesEndDate = mockData.specifiedSalesEndDate,
-                        tags = mockData.tags.map { tag -> tag.tag },
+                        tags = mockData.tags.map { tag -> tag.name },
                         content = mockData.content,
                         inputStatus = mockData.inputStatus,
                         itemIds = mockData.items.map { item -> item.itemId },
@@ -373,7 +373,7 @@ class ProductRouterTest {
                         specifiedSalesEndDate = firstMockData.specifiedSalesEndDate,
                         inputStatus = firstMockData.inputStatus,
                         updatedAt = firstMockData.updatedAt,
-                        tags = firstMockData.tags.map { tag -> tag.tag }
+                        tags = firstMockData.tags.map { tag -> tag.name }
                     )
                 )
         )

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -316,10 +316,10 @@ class ProductRouterTest {
                         representativeImageUrl = mockData.representativeImageUrl,
                         specifiedSalesStartDate = mockData.specifiedSalesStartDate,
                         specifiedSalesEndDate = mockData.specifiedSalesEndDate,
-                        tags = mockData.tags,
+                        tags = mockData.tags.map { tag -> tag.tag },
                         content = mockData.content,
                         inputStatus = mockData.inputStatus,
-                        items = mockData.items,
+                        itemIds = mockData.items.map { item -> item.itemId },
                         createdAt = mockData.createdAt,
                         updatedAt = mockData.updatedAt,
                     )

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
@@ -6,13 +6,13 @@ fun GetMyProductResponse.like(other: GetMyProductResponse): Boolean {
     if (this === other) return true
     tags.mapIndexed {
         index, tag ->
-        if (other.tags[index].tag != tag.tag) {
+        if (other.tags[index] != tag) {
             return false
         }
     }
-    items.mapIndexed {
+    itemIds.mapIndexed {
         index, item ->
-        if (other.items[index].itemId != item.itemId) {
+        if (other.itemIds[index] != item) {
             return false
         }
     }

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductsResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductsResponse.kt
@@ -1,0 +1,22 @@
+package com.kroffle.knitting.helper.extension
+
+import com.kroffle.knitting.controller.handler.product.dto.GetMyProductsResponse
+
+fun GetMyProductsResponse.like(other: GetMyProductsResponse): Boolean {
+    if (this === other) return true
+    tags.mapIndexed {
+        index, tag ->
+        if (other.tags[index] != tag) {
+            return false
+        }
+    }
+    return id == other.id &&
+        name == other.name &&
+        fullPrice == other.fullPrice &&
+        discountPrice == other.discountPrice &&
+        representativeImageUrl == other.representativeImageUrl &&
+        specifiedSalesStartDate == other.specifiedSalesStartDate &&
+        specifiedSalesEndDate == other.specifiedSalesEndDate &&
+        inputStatus == other.inputStatus &&
+        updatedAt == other.updatedAt
+}

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
@@ -6,7 +6,7 @@ fun Product.like(other: Product): Boolean {
     if (this === other) return true
     tags.mapIndexed {
         index, tag ->
-        if (other.tags[index].tag != tag.tag) {
+        if (other.tags[index].name != tag.name) {
             return false
         }
     }


### PR DESCRIPTION
## PR 제안 사유
내 상품 리스트를 조회할 수 있도록 API를 추가합니다.

Resolves #90

## 주요 변경 기록

- itemIds, tags API에서 내려줄 때 필요한 값만 내려주도록 수정
- pagination cursor에 id외에 다른 타입도 사용할 수 있도록 String으로 변경
- 내가 작성한 상품 조회하는 API 구현
- 사소한 리팩토링 - 줄바꿈 수정
- product_tag의 tag 멤버 name으로 이름 변경


## 이어서 작업해야 하는 이슈
https://github.com/k-roffle/knitting-service/issues/119
https://github.com/k-roffle/knitting-service/issues/120
https://github.com/k-roffle/knitting-service/issues/121