### PR TITLE
feat: draft API에서 상품 구성 업데이트 할 수 있도록 수정

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -73,6 +73,35 @@ class Product(
             salesStatus == SalesStatus.ON_SALES &&
                 inputStatus == InputStatus.REGISTERED
 
+    fun draftPackage(
+        knitterId: Long,
+        name: String,
+        fullPrice: Money,
+        discountPrice: Money,
+        representativeImageUrl: String,
+        specifiedSalesStartDate: LocalDate?,
+        specifiedSalesEndDate: LocalDate?,
+        tags: List<ProductTag>,
+        items: List<ProductItem>,
+    ): Product {
+        return Product(
+            id,
+            knitterId,
+            name,
+            fullPrice,
+            discountPrice,
+            representativeImageUrl,
+            specifiedSalesStartDate,
+            specifiedSalesEndDate,
+            tags,
+            content,
+            inputStatus,
+            items,
+            createdAt,
+            LocalDateTime.now(),
+        )
+    }
+
     fun draftContent(newContent: String): Product {
         return Product(
             id,
@@ -116,7 +145,6 @@ class Product(
 
     companion object {
         fun draftProductPackage(
-            id: Long?,
             knitterId: Long,
             name: String,
             fullPrice: Money,
@@ -128,7 +156,7 @@ class Product(
             items: List<ProductItem>,
         ): Product {
             return Product(
-                id,
+                null,
                 knitterId,
                 name,
                 fullPrice,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductItemRepository.kt
@@ -3,8 +3,10 @@ package com.kroffle.knitting.infra.persistence.product.repository
 import com.kroffle.knitting.infra.persistence.product.entity.ProductItemEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface DBProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductItemEntity>
     fun findAllByProductIdIn(productId: List<Long>): Flux<ProductItemEntity>
+    fun deleteByProductId(productId: Long): Mono<Long>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductTagRepository.kt
@@ -3,8 +3,10 @@ package com.kroffle.knitting.infra.persistence.product.repository
 import com.kroffle.knitting.infra.persistence.product.entity.ProductTagEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface DBProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductTagEntity>
     fun findAllByProductIdIn(productId: List<Long>): Flux<ProductTagEntity>
+    fun deleteByProductId(productId: Long): Mono<Long>
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -17,7 +17,6 @@ class ProductService(private val repository: ProductRepository) {
     fun draft(data: DraftProductPackageData): Mono<Product> =
         repository.save(
             Product.draftProductPackage(
-                id = data.id,
                 knitterId = data.knitterId,
                 name = data.name,
                 fullPrice = data.fullPrice,

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -15,19 +15,38 @@ import reactor.core.publisher.Mono
 @Component
 class ProductService(private val repository: ProductRepository) {
     fun draft(data: DraftProductPackageData): Mono<Product> =
-        repository.save(
-            Product.draftProductPackage(
-                knitterId = data.knitterId,
-                name = data.name,
-                fullPrice = data.fullPrice,
-                discountPrice = data.discountPrice,
-                representativeImageUrl = data.representativeImageUrl,
-                specifiedSalesStartDate = data.specifiedSalesStartDate,
-                specifiedSalesEndDate = data.specifiedSalesEndDate,
-                tags = data.tags,
-                items = data.items,
+        if (data.id == null) {
+            repository.save(
+                Product.draftProductPackage(
+                    knitterId = data.knitterId,
+                    name = data.name,
+                    fullPrice = data.fullPrice,
+                    discountPrice = data.discountPrice,
+                    representativeImageUrl = data.representativeImageUrl,
+                    specifiedSalesStartDate = data.specifiedSalesStartDate,
+                    specifiedSalesEndDate = data.specifiedSalesEndDate,
+                    tags = data.tags,
+                    items = data.items,
+                )
             )
-        )
+        } else {
+            repository
+                .getProductByIdAndKnitterId(data.id, data.knitterId)
+                .flatMap {
+                    val updatedProduct = it.draftPackage(
+                        knitterId = data.knitterId,
+                        name = data.name,
+                        fullPrice = data.fullPrice,
+                        discountPrice = data.discountPrice,
+                        representativeImageUrl = data.representativeImageUrl,
+                        specifiedSalesStartDate = data.specifiedSalesStartDate,
+                        specifiedSalesEndDate = data.specifiedSalesEndDate,
+                        tags = data.tags,
+                        items = data.items,
+                    )
+                    repository.save(updatedProduct)
+                }
+        }
 
     fun draft(data: DraftProductContentData): Mono<Product> {
         return repository


### PR DESCRIPTION
## PR 제안 사유
- draft 상태의 상품은 수정할 수 있어야 하므로 API를 수정합니다.
- 처음 상품을 만들고 다음버튼을 눌렀을 때와 만들어둔 상품을 수정후 다음 버튼을 눌렀을 때 동일한 API를 사용하면 됩니다.
  - 단, 처음 상품을 만들 때에는 id를 null로 전달해야하고, 수정할 때에는 수정하는 상품의 id를 전달해야 합니다.

Resolves #99

## 주요 변경 기록
- 도메인 함수 추가
- draft API에서 상품 수정할 수 있도록 수정

## API Spec
https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-bdfc6847-83d4-4a0d-8d60-d57381072cb6

## 고민

- 수정 요청 할 때 기존에 어떤 entity였는지 알 수 없어서.. 기존에 있던 tag, item들을 모두 삭제하고 다시 만드는데 더 좋은 방법 없나 싶네요 🤔 
