### PR TITLE
feat: value class에서 id member 제거

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -53,8 +53,8 @@ class ProductHandler(private val productService: ProductService) {
                     representativeImageUrl = body.representativeImageUrl,
                     specifiedSalesStartDate = body.specifiedSalesStartDate,
                     specifiedSalesEndDate = body.specifiedSalesEndDate,
-                    tags = body.tags.map { ProductTag(null, it, null) },
-                    items = body.designIds.map { ProductItem.create(null, it, null, ProductItemType.DESIGN) },
+                    tags = body.tags.map { ProductTag(it, null) },
+                    items = body.designIds.map { ProductItem.create(it, null, ProductItemType.DESIGN) },
                 )
             )
         }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
@@ -4,10 +4,9 @@ import com.kroffle.knitting.domain.product.enum.ProductItemType
 import java.time.LocalDateTime
 
 class DesignProductItem(
-    id: Long?,
     itemId: Long,
     createdAt: LocalDateTime?,
-) : ProductItem(id, itemId, createdAt) {
+) : ProductItem(itemId, createdAt) {
     override val type: ProductItemType
         get() = ProductItemType.DESIGN
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
@@ -4,10 +4,9 @@ import com.kroffle.knitting.domain.product.enum.ProductItemType
 import java.time.LocalDateTime
 
 class GoodsProductItem(
-    id: Long?,
     itemId: Long,
     createdAt: LocalDateTime?,
-) : ProductItem(id, itemId, createdAt) {
+) : ProductItem(itemId, createdAt) {
     override val type: ProductItemType
         get() = ProductItemType.GOODS
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
@@ -3,19 +3,17 @@ package com.kroffle.knitting.domain.product.value
 import com.kroffle.knitting.domain.product.enum.ProductItemType
 import java.time.LocalDateTime
 
-/* FIXME: #99 이슈 진행하며 id 제거가 가능하다면 제거, 불가능하다면 entity 로 변경합니다. */
 abstract class ProductItem(
-    val id: Long?,
     val itemId: Long,
     val createdAt: LocalDateTime?,
 ) {
     abstract val type: ProductItemType
 
     companion object {
-        fun create(id: Long?, itemId: Long, createdAt: LocalDateTime?, type: ProductItemType): ProductItem {
+        fun create(itemId: Long, createdAt: LocalDateTime?, type: ProductItemType): ProductItem {
             return when (type) {
-                ProductItemType.DESIGN -> DesignProductItem(id, itemId, createdAt)
-                ProductItemType.GOODS -> GoodsProductItem(id, itemId, createdAt)
+                ProductItemType.DESIGN -> DesignProductItem(itemId, createdAt)
+                ProductItemType.GOODS -> GoodsProductItem(itemId, createdAt)
             }
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
@@ -2,9 +2,7 @@ package com.kroffle.knitting.domain.product.value
 
 import java.time.LocalDateTime
 
-/* FIXME: #99 이슈 진행하며 id 제거가 가능하다면 제거, 불가능하다면 entity 로 변경합니다. */
 data class ProductTag(
-    val id: Long?,
     val name: String,
     val createdAt: LocalDateTime?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
@@ -15,7 +15,7 @@ class ProductItemEntity(
     private val type: ProductItemType,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
-    fun toItem() = ProductItem.create(id, itemId, createdAt, type)
+    fun toItem() = ProductItem.create(itemId, createdAt, type)
     fun getForeignKey(): Long = productId
 }
 
@@ -23,7 +23,6 @@ fun Product.toProductItemEntities(productId: Long): List<ProductItemEntity> =
     this.items.map {
         item ->
         ProductItemEntity(
-            id = item.id,
             productId = this.id ?: productId,
             itemId = item.itemId,
             type = item.type,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
@@ -14,7 +14,6 @@ class ProductTagEntity(
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
     fun toTag() = ProductTag(
-        id = id,
         name = name,
         createdAt = createdAt,
     )
@@ -25,7 +24,7 @@ fun Product.toProductTagEntities(productId: Long): List<ProductTagEntity> =
     this.tags.map {
         tag ->
         ProductTagEntity(
-            id = tag.id,
+            id = null,
             productId = this.id ?: productId,
             name = tag.name,
             createdAt = tag.createdAt ?: LocalDateTime.now(),

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -90,11 +90,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag(1, "서술형도안", today),
-                ProductTag(2, "초보자용", today),
+                ProductTag("서술형도안", today),
+                ProductTag("초보자용", today),
             ),
             items = listOf(
-                ProductItem.create(1, 1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, today, ProductItemType.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -169,11 +169,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag(1, "서술형도안", today),
-                ProductTag(2, "초보자용", today),
+                ProductTag("서술형도안", today),
+                ProductTag("초보자용", today),
             ),
             items = listOf(
-                ProductItem.create(1, 1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, today, ProductItemType.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -187,8 +187,8 @@ class ProductRouterTest {
                 representativeImageUrl = "http://test2.knitting.com/image.jpg",
                 specifiedSalesStartDate = tomorrow.toLocalDate(),
                 specifiedSalesEndDate = null,
-                tags = listOf(ProductTag(null, "서술형도안", today)),
-                items = listOf(ProductItem.create(null, 2, today, ProductItemType.DESIGN))
+                tags = listOf(ProductTag("서술형도안", today)),
+                items = listOf(ProductItem.create(2, today, ProductItemType.DESIGN))
             )
         given(repository.getProductByIdAndKnitterId(any(), any()))
             .willReturn(Mono.just(targetProduct))
@@ -273,11 +273,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag(1, "서술형도안", today),
-                ProductTag(2, "초보자용", today),
+                ProductTag("서술형도안", today),
+                ProductTag("초보자용", today),
             ),
             items = listOf(
-                ProductItem.create(1, 1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, today, ProductItemType.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,
@@ -340,11 +340,11 @@ class ProductRouterTest {
             content = "이번에는 초보탈출 패키지를 준비해봤어요.",
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag(1, "서술형도안", today),
-                ProductTag(2, "초보자용", today),
+                ProductTag("서술형도안", today),
+                ProductTag("초보자용", today),
             ),
             items = listOf(
-                ProductItem.create(1, 1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, today, ProductItemType.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,


### PR DESCRIPTION
## PR 제안 사유
- value class인 ProductTag와 ProductItem에서 id 멤버를 제거합니다.
- id가 존재하면 기존에 삭제하고 다시 만드는 로직에서 id를 가지고 기존 row를 업데이트 하려고 하면서 버그가 발생합니다.
  - 도메인에서 entity로 매핑할 때 id를 넘겨주지 않도록 하여 해당 버그를 수정합니다.

Resolves #99

## 주요 변경 기록
- value class에서 id 제거
