### PR TITLE
feat: 도안에 기법 리스트 저장할 수 있도록 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -11,6 +11,7 @@ import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
 import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
@@ -67,7 +68,7 @@ class DesignHandler(private val service: DesignService) {
                         description = it.description,
                         targetLevel = it.targetLevel,
                         coverImageUrl = it.coverImageUrl,
-                        techniques = listOf(),
+                        techniques = it.techniques.map { technique -> Technique(technique) },
                     )
                 )
             }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -7,12 +7,12 @@ import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
-import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
@@ -32,7 +32,7 @@ class DesignHandler(private val service: DesignService) {
         return design
             .flatMap {
                 service.create(
-                    Design(
+                    CreateDesignData(
                         knitterId = knitterId,
                         name = it.name,
                         designType = it.designType,
@@ -67,7 +67,7 @@ class DesignHandler(private val service: DesignService) {
                         description = it.description,
                         targetLevel = it.targetLevel,
                         coverImageUrl = it.coverImageUrl,
-                        createdAt = null,
+                        techniques = listOf(),
                     )
                 )
             }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesignRequest.kt
@@ -23,4 +23,5 @@ data class NewDesignRequest(
     val targetLevel: LevelType,
     @JsonProperty("cover_image_url")
     val coverImageUrl: String,
+    val techniques: List<String>,
 )

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -6,6 +6,7 @@ import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
 import java.time.LocalDateTime
 
 class Design(
@@ -23,5 +24,6 @@ class Design(
     val description: String,
     val targetLevel: LevelType,
     val coverImageUrl: String,
+    val techniques: List<Technique>,
     val createdAt: LocalDateTime?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -26,4 +26,40 @@ class Design(
     val coverImageUrl: String,
     val techniques: List<Technique>,
     val createdAt: LocalDateTime?,
-)
+) {
+    companion object {
+        fun new(
+            knitterId: Long,
+            name: String,
+            designType: DesignType,
+            patternType: PatternType,
+            gauge: Gauge,
+            size: Size,
+            needle: String,
+            yarn: String,
+            extra: String?,
+            pattern: Pattern,
+            description: String,
+            targetLevel: LevelType,
+            coverImageUrl: String,
+            techniques: List<Technique>,
+        ) = Design(
+            id = null,
+            knitterId = knitterId,
+            name = name,
+            designType = designType,
+            patternType = patternType,
+            gauge = gauge,
+            size = size,
+            needle = needle,
+            yarn = yarn,
+            extra = extra,
+            pattern = pattern,
+            description = description,
+            targetLevel = targetLevel,
+            coverImageUrl = coverImageUrl,
+            techniques = techniques,
+            createdAt = null,
+        )
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/value/Technique.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/value/Technique.kt
@@ -1,0 +1,3 @@
+package com.kroffle.knitting.domain.design.value
+
+data class Technique(val name: String)

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -8,6 +8,7 @@ import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
@@ -35,7 +36,7 @@ class DesignEntity(
     private val coverImageUrl: String,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
-    fun toDesign(): Design =
+    fun toDesign(techniques: List<Technique>): Design =
         Design(
             id = this.id,
             knitterId = this.knitterId,
@@ -57,6 +58,7 @@ class DesignEntity(
             description = this.description,
             targetLevel = LevelType.getFromKey(this.targetLevel),
             coverImageUrl = this.coverImageUrl,
+            techniques = techniques,
             createdAt = this.createdAt,
         )
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -36,6 +36,8 @@ class DesignEntity(
     private val coverImageUrl: String,
     private val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
+    fun getNotNullId(): Long = id!!
+
     fun toDesign(techniques: List<Technique>): Design =
         Design(
             id = this.id,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/TechniqueEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/TechniqueEntity.kt
@@ -1,0 +1,23 @@
+package com.kroffle.knitting.infra.persistence.design.entity
+
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.design.value.Technique
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+
+@Table("technique")
+class TechniqueEntity(
+    @Id private var id: Long? = null,
+    private val designId: Long,
+    private val name: String,
+) {
+    fun toTechnique() = Technique(name)
+}
+
+fun Design.toTechniqueEntities(designId: Long): List<TechniqueEntity> =
+    this.techniques.map { technique ->
+        TechniqueEntity(
+            name = technique.name,
+            designId = this.id ?: designId,
+        )
+    }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/TechniqueEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/TechniqueEntity.kt
@@ -12,6 +12,8 @@ class TechniqueEntity(
     private val name: String,
 ) {
     fun toTechnique() = Technique(name)
+
+    fun getForeignKey() = designId
 }
 
 fun Design.toTechniqueEntities(designId: Long): List<TechniqueEntity> =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DBTechniqueRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DBTechniqueRepository.kt
@@ -1,0 +1,11 @@
+package com.kroffle.knitting.infra.persistence.design.repository
+
+import com.kroffle.knitting.infra.persistence.design.entity.TechniqueEntity
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+interface DBTechniqueRepository : ReactiveCrudRepository<TechniqueEntity, Long> {
+    fun deleteByDesignId(designId: Long): Mono<Long>
+    fun findAllByDesignIdIn(designIds: List<Long>): Flux<TechniqueEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2dbcDesignRepository.kt
@@ -2,7 +2,9 @@ package com.kroffle.knitting.infra.persistence.design.repository
 
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
+import com.kroffle.knitting.infra.persistence.design.entity.TechniqueEntity
 import com.kroffle.knitting.infra.persistence.design.entity.toDesignEntity
+import com.kroffle.knitting.infra.persistence.design.entity.toTechniqueEntities
 import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
@@ -11,13 +13,60 @@ import com.kroffle.knitting.usecase.repository.DesignRepository
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.util.stream.Collectors.toList
 
 @Component
-class R2dbcDesignRepository(private val repository: DBDesignRepository) : DesignRepository {
+class R2dbcDesignRepository(
+    private val designRepository: DBDesignRepository,
+    private val techniqueRepository: DBTechniqueRepository,
+) : DesignRepository {
     override fun createDesign(design: Design): Mono<Design> =
-        repository
+        designRepository
             .save(design.toDesignEntity())
-            .map { it.toDesign() }
+            .flatMap { designEntity ->
+                val designId: Long = designEntity.getNotNullId()
+                val techniques =
+                    techniqueRepository
+                        .deleteByDesignId(designId)
+                        .flatMap {
+                            techniqueRepository
+                                .saveAll(design.toTechniqueEntities(designId))
+                                .map { it.toTechnique() }
+                                .collect(toList())
+                        }
+                techniques.map {
+                    designEntity.toDesign(techniques = it)
+                }
+            }
+
+    private fun getDesignAggregate(designs: Flux<DesignEntity>): Flux<Design> {
+        val designIds: Mono<List<Long>> =
+            designs
+                .map { design -> design.getNotNullId() }
+                .collect(toList())
+
+        val techniqueMap: Mono<Map<Long, Collection<TechniqueEntity>>> =
+            designIds
+                .flatMap {
+                    techniqueRepository
+                        .findAllByDesignIdIn(it)
+                        .collectMultimap { technique -> technique.getForeignKey() }
+                }
+
+        return designs
+            .concatMap { design ->
+                techniqueMap
+                    .map { techniques ->
+                        val designId = design.getNotNullId()
+                        design
+                            .toDesign(
+                                techniques[designId]
+                                    ?.map { technique -> technique.toTechnique() }
+                                    ?: listOf()
+                            )
+                    }
+            }
+    }
 
     override fun getDesignsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Design> {
         val pageRequest = PaginationHelper.makePageRequest(paging, sort)
@@ -25,14 +74,14 @@ class R2dbcDesignRepository(private val repository: DBDesignRepository) : Design
         val designs: Flux<DesignEntity> = when (sort.direction) {
             SortDirection.DESC ->
                 if (paging.after != null) {
-                    repository
+                    designRepository
                         .findAllByKnitterIdAndIdBefore(
                             knitterId = knitterId,
                             id = paging.after.toLong(),
                             pageable = pageRequest,
                         )
                 } else {
-                    repository
+                    designRepository
                         .findAllByKnitterId(
                             knitterId = knitterId,
                             pageable = pageRequest,
@@ -40,6 +89,6 @@ class R2dbcDesignRepository(private val repository: DBDesignRepository) : Design
                 }
             else -> throw NotImplementedError()
         }
-        return designs.map { it.toDesign() }
+        return getDesignAggregate(designs)
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -66,8 +66,7 @@ class R2dbcProductRepository(
                 }
 
         return products
-            .concatMap {
-                product ->
+            .concatMap { product ->
                 Mono.zip(tagMap, itemMap)
                     .map {
                         val productId = product.getNotNullId()

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.usecase.design
 
 import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
@@ -10,7 +11,26 @@ import reactor.core.publisher.Mono
 
 @Component
 class DesignService(private val repository: DesignRepository) {
-    fun create(design: Design): Mono<Design> = repository.createDesign(design)
+    fun create(data: CreateDesignData): Mono<Design> =
+        repository
+            .createDesign(
+                Design.new(
+                    data.knitterId,
+                    data.name,
+                    data.designType,
+                    data.patternType,
+                    data.gauge,
+                    data.size,
+                    data.needle,
+                    data.yarn,
+                    data.extra,
+                    data.pattern,
+                    data.description,
+                    data.targetLevel,
+                    data.coverImageUrl,
+                    data.techniques,
+                )
+            )
 
     fun getMyDesign(filter: MyDesignFilter): Flux<Design> =
         repository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
@@ -1,0 +1,26 @@
+package com.kroffle.knitting.usecase.design.dto
+
+import com.kroffle.knitting.domain.design.enum.DesignType
+import com.kroffle.knitting.domain.design.enum.LevelType
+import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.domain.design.value.Gauge
+import com.kroffle.knitting.domain.design.value.Pattern
+import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
+
+data class CreateDesignData(
+    val knitterId: Long,
+    val name: String,
+    val designType: DesignType,
+    val patternType: PatternType,
+    val gauge: Gauge,
+    val size: Size,
+    val needle: String,
+    val yarn: String,
+    val extra: String?,
+    val pattern: Pattern,
+    val description: String,
+    val targetLevel: LevelType,
+    val coverImageUrl: String,
+    val techniques: List<Technique>,
+)

--- a/src/main/resources/db/migration/V7__add_technique_table.sql
+++ b/src/main/resources/db/migration/V7__add_technique_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE technique (
+    id BIGSERIAL NOT NULL,
+    design_id bigint NOT NULL REFERENCES design(id),
+    name VARCHAR NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -2,15 +2,20 @@ package com.kroffle.knitting.controller.router.design
 
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
+import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.LevelType
 import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.domain.design.value.Gauge
+import com.kroffle.knitting.domain.design.value.Length
+import com.kroffle.knitting.domain.design.value.Pattern
+import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
 import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
 import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
-import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
@@ -59,28 +64,33 @@ class DesignsRouterTest {
         given(repository.getDesignsByKnitterId(any(), any(), any()))
             .willReturn(
                 Flux.just(
-                    DesignEntity(
+                    Design(
                         id = 1,
                         knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
                         name = "캔디리더 효정 니트",
                         designType = DesignType.Sweater,
                         patternType = PatternType.Text,
-                        stitches = 23.5,
-                        rows = 25.0,
-                        totalLength = 1.0,
-                        sleeveLength = 2.0,
-                        shoulderWidth = 3.0,
-                        bottomWidth = 4.0,
-                        armholeDepth = 5.0,
+                        gauge = Gauge(
+                            stitches = 23.5,
+                            rows = 25.0,
+                        ),
+                        size = Size(
+                            totalLength = Length(1.0),
+                            sleeveLength = Length(2.0),
+                            shoulderWidth = Length(3.0),
+                            bottomWidth = Length(4.0),
+                            armholeDepth = Length(5.0),
+                        ),
                         needle = "5.0mm",
                         yarn = "패션아란 400g 1볼",
                         extra = null,
-                        pattern = "# Step1. 코를 10개 잡습니다.",
+                        pattern = Pattern("# Step1. 코를 10개 잡습니다."),
                         description = "이건 니트를 만드는 서술형 도안입니다.",
-                        targetLevel = LevelType.HARD.key,
+                        targetLevel = LevelType.HARD,
                         coverImageUrl = "http://test.kroffle.com/image.jpg",
+                        techniques = listOf(Technique("안뜨기"), Technique("겉뜨기")),
                         createdAt = today,
-                    ).toDesign()
+                    )
                 )
             )
 


### PR DESCRIPTION
## PR 제안 사유

- 도안에 어떤 기법이 포함되어있는지 저장할 수 있도록 합니다.
  - 도안 구매자가 스스로 본인에게 어려운 도안인지, 쉬운 도안인지 판단할 수 있도록 기법을 제공합니다.

Resolves #125

## 주요 변경 기록

- technique value 객체 추가
- domain & entity에 techniques 추가
- 도안 생성 API에 반영

## API Request Spec

https://kroffle.postman.co/workspace/Knitting-Workspace~f5f42d30-6553-40d3-8bb6-91bb318aad19/request/5081988-c3d5ea82-01d4-4ab5-bf3d-1b61d89b419b

"techniques" 키가 추가 되었습니다~
없으면 요청 실패할거라서 클라이언트에서 수정해줘야 도안 생성 가능할거에요!
