### PR TITLE
refactor: 도안 테이블에서 사이즈 정보 분리

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -43,19 +43,19 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
         if (path in PUBLIC_PATHS) {
             return chain.filter(exchange)
         }
-        return getAuthorization(headers = exchange.request.headers).doOnError {
-            error ->
-            val message = error.message
-            if (message != null) {
-                val byteMessages = message.toByteArray()
-                val buffer = exchange.response.bufferFactory().wrap(byteMessages)
-                exchange.response.writeWith(Flux.just(buffer))
-            }
-        }.doOnSuccess {
-            exchange.attributes["knitterId"] = it
-        }.then(
-            chain.filter(exchange)
-        )
+        return getAuthorization(headers = exchange.request.headers)
+            .doOnError { error ->
+                val message = error.message
+                if (message != null) {
+                    val byteMessages = message.toByteArray()
+                    val buffer = exchange.response.bufferFactory().wrap(byteMessages)
+                    exchange.response.writeWith(Flux.just(buffer))
+                }
+            }.doOnSuccess {
+                exchange.attributes["knitterId"] = it
+            }.then(
+                chain.filter(exchange)
+            )
     }
 
     interface TokenDecoder {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -90,8 +90,7 @@ class DesignHandler(private val service: DesignService) {
                     Sort("id", SortDirection.DESC),
                 )
             )
-            .map {
-                design ->
+            .map { design ->
                 MyDesign(
                     id = design.id!!,
                     name = design.name,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
@@ -20,8 +20,7 @@ class MyselfHandler(
         val knitterId = AuthHelper.getKnitterId(req)
         return knitterService
             .getKnitter(knitterId)
-            .map {
-                knitter ->
+            .map { knitter ->
                 MyProfileResponse(
                     email = knitter.email,
                     name = knitter.name,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -41,23 +41,23 @@ class ProductHandler(private val productService: ProductService) {
             .bodyToMono(EditProductPackageRequest::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
-        val product: Mono<Product> = bodyMono.flatMap {
-            body ->
-            productService.edit(
-                EditProductPackageData(
-                    id = body.id,
-                    knitterId = knitterId,
-                    name = body.name,
-                    fullPrice = Money(body.fullPrice),
-                    discountPrice = Money(body.discountPrice),
-                    representativeImageUrl = body.representativeImageUrl,
-                    specifiedSalesStartDate = body.specifiedSalesStartDate,
-                    specifiedSalesEndDate = body.specifiedSalesEndDate,
-                    tags = body.tags.map { ProductTag(it, null) },
-                    items = body.designIds.map { ProductItem.create(it, null, ProductItemType.DESIGN) },
+        val product: Mono<Product> = bodyMono
+            .flatMap { body ->
+                productService.edit(
+                    EditProductPackageData(
+                        id = body.id,
+                        knitterId = knitterId,
+                        name = body.name,
+                        fullPrice = Money(body.fullPrice),
+                        discountPrice = Money(body.discountPrice),
+                        representativeImageUrl = body.representativeImageUrl,
+                        specifiedSalesStartDate = body.specifiedSalesStartDate,
+                        specifiedSalesEndDate = body.specifiedSalesEndDate,
+                        tags = body.tags.map { ProductTag(it, null) },
+                        items = body.designIds.map { ProductItem.create(it, null, ProductItemType.DESIGN) },
+                    )
                 )
-            )
-        }
+            }
 
         return product
             .flatMap {
@@ -74,16 +74,16 @@ class ProductHandler(private val productService: ProductService) {
             .bodyToMono(EditProductContentRequest::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
-        val product: Mono<Product> = bodyMono.flatMap {
-            body ->
-            productService.edit(
-                EditProductContentData(
-                    id = body.id,
-                    knitterId = knitterId,
-                    content = body.content,
+        val product: Mono<Product> = bodyMono
+            .flatMap { body ->
+                productService.edit(
+                    EditProductContentData(
+                        id = body.id,
+                        knitterId = knitterId,
+                        content = body.content,
+                    )
                 )
-            )
-        }
+            }
 
         return product
             .onErrorResume { Mono.error(BadRequest(it.message)) }
@@ -101,15 +101,15 @@ class ProductHandler(private val productService: ProductService) {
             .bodyToMono(RegisterProductRequest::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
-        val product: Mono<Product> = bodyMono.flatMap {
-            body ->
-            productService.register(
-                RegisterProductData(
-                    id = body.id,
-                    knitterId = knitterId,
+        val product: Mono<Product> = bodyMono
+            .flatMap { body ->
+                productService.register(
+                    RegisterProductData(
+                        id = body.id,
+                        knitterId = knitterId,
+                    )
                 )
-            )
-        }
+            }
         return product
             .onErrorResume { Mono.error(BadRequest(it.message)) }
             .flatMap {

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
@@ -70,8 +70,7 @@ class GoogleOAuthHelperImpl(
         return getAccessToken(code).flatMap {
             webClient
                 .get()
-                .uri {
-                    uriBuilder ->
+                .uri { uriBuilder ->
                     uriBuilder
                         .path("/oauth2/v3/userinfo")
                         .queryParam("access_token", it)

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -5,7 +5,6 @@ import com.kroffle.knitting.domain.design.enum.DesignType
 import com.kroffle.knitting.domain.design.enum.LevelType
 import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
-import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
@@ -22,11 +21,6 @@ class DesignEntity(
     private val patternType: PatternType,
     private val stitches: Double,
     private val rows: Double,
-    private val totalLength: Double,
-    private val sleeveLength: Double,
-    private val shoulderWidth: Double,
-    private val bottomWidth: Double,
-    private val armholeDepth: Double,
     private val needle: String,
     private val yarn: String,
     private val extra: String?,
@@ -38,7 +32,7 @@ class DesignEntity(
 ) {
     fun getNotNullId(): Long = id!!
 
-    fun toDesign(techniques: List<Technique>): Design =
+    fun toDesign(techniques: List<Technique>, size: Size): Design =
         Design(
             id = this.id,
             knitterId = this.knitterId,
@@ -46,13 +40,7 @@ class DesignEntity(
             designType = this.designType,
             patternType = this.patternType,
             gauge = Gauge(this.stitches, this.rows),
-            size = Size(
-                totalLength = Length(this.totalLength),
-                sleeveLength = Length(this.sleeveLength),
-                shoulderWidth = Length(this.shoulderWidth),
-                bottomWidth = Length(this.bottomWidth),
-                armholeDepth = Length(this.armholeDepth),
-            ),
+            size = size,
             needle = this.needle,
             yarn = this.yarn,
             extra = this.extra,
@@ -74,11 +62,6 @@ fun Design.toDesignEntity() =
         patternType = this.patternType,
         stitches = this.gauge.stitches,
         rows = this.gauge.rows,
-        totalLength = this.size.totalLength.value,
-        sleeveLength = this.size.sleeveLength.value,
-        shoulderWidth = this.size.shoulderWidth.value,
-        bottomWidth = this.size.bottomWidth.value,
-        armholeDepth = this.size.armholeDepth.value,
         needle = this.needle,
         yarn = this.yarn,
         extra = this.extra,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
@@ -26,6 +26,8 @@ class SizeEntity(
             armholeDepth = Length(armholeDepth, DEFAULT_UNIT),
         )
 
+    fun getForeignKey() = designId
+
     companion object {
         private val DEFAULT_UNIT = SizeUnitType.Cm
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
@@ -1,0 +1,42 @@
+package com.kroffle.knitting.infra.persistence.design.entity
+
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.design.enum.SizeUnitType
+import com.kroffle.knitting.domain.design.value.Length
+import com.kroffle.knitting.domain.design.value.Size
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+
+@Table("size")
+class SizeEntity(
+    @Id private var id: Long? = null,
+    private val designId: Long,
+    private val totalLength: Double,
+    private val sleeveLength: Double,
+    private val shoulderWidth: Double,
+    private val bottomWidth: Double,
+    private val armholeDepth: Double,
+) {
+    fun toSize() =
+        Size(
+            totalLength = Length(totalLength, DEFAULT_UNIT),
+            sleeveLength = Length(sleeveLength, DEFAULT_UNIT),
+            shoulderWidth = Length(shoulderWidth, DEFAULT_UNIT),
+            bottomWidth = Length(bottomWidth, DEFAULT_UNIT),
+            armholeDepth = Length(armholeDepth, DEFAULT_UNIT),
+        )
+
+    companion object {
+        private val DEFAULT_UNIT = SizeUnitType.Cm
+    }
+}
+
+fun Design.toSizeEntity(designId: Long): SizeEntity =
+    SizeEntity(
+        designId = id ?: designId,
+        totalLength = size.totalLength.value,
+        sleeveLength = size.sleeveLength.value,
+        shoulderWidth = size.shoulderWidth.value,
+        bottomWidth = size.bottomWidth.value,
+        armholeDepth = size.armholeDepth.value,
+    )

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DBSizeRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DBSizeRepository.kt
@@ -1,0 +1,11 @@
+package com.kroffle.knitting.infra.persistence.design.repository
+
+import com.kroffle.knitting.infra.persistence.design.entity.SizeEntity
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+interface DBSizeRepository : ReactiveCrudRepository<SizeEntity, Long> {
+    fun deleteByDesignId(designId: Long): Mono<Long>
+    fun findAllByDesignIdIn(designIds: List<Long>): Flux<SizeEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
@@ -20,8 +20,7 @@ class ProductItemEntity(
 }
 
 fun Product.toProductItemEntities(productId: Long): List<ProductItemEntity> =
-    this.items.map {
-        item ->
+    this.items.map { item ->
         ProductItemEntity(
             productId = this.id ?: productId,
             itemId = item.itemId,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
@@ -21,8 +21,7 @@ class ProductTagEntity(
 }
 
 fun Product.toProductTagEntities(productId: Long): List<ProductTagEntity> =
-    this.tags.map {
-        tag ->
+    this.tags.map { tag ->
         ProductTagEntity(
             id = null,
             productId = this.id ?: productId,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -43,7 +43,7 @@ class R2dbcProductRepository(
             .map { it.t1.toProduct(it.t2, it.t3) }
     }
 
-    private fun getProductAggregate(products: Flux<ProductEntity>): Flux<Product> {
+    private fun getProductAggregates(products: Flux<ProductEntity>): Flux<Product> {
         val productIds: Mono<List<Long>> =
             products
                 .map { product -> product.getNotNullId() }
@@ -133,13 +133,13 @@ class R2dbcProductRepository(
                 }
             else -> throw NotImplementedError()
         }
-        return getProductAggregate(products)
+        return getProductAggregates(products)
     }
 
     override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
         val products: Flux<ProductEntity> =
             productRepository
                 .findAllByKnitterIdAndInputStatus(knitterId, InputStatus.REGISTERED)
-        return getProductAggregate(products)
+        return getProductAggregates(products)
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -80,8 +80,7 @@ class R2dbcProductRepository(
     override fun save(product: Product): Mono<Product> {
         return productRepository
             .save(product.toProductEntity())
-            .flatMap {
-                productEntity ->
+            .flatMap { productEntity ->
                 val productId: Long = productEntity.getNotNullId()
 
                 val tags = productTagRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -16,8 +16,7 @@ class AuthService(
     fun authorize(code: String): Mono<String> {
         return oAuthHelper
             .getProfile(code)
-            .flatMap {
-                profile ->
+            .flatMap { profile ->
                 knitterRepository
                     .findByEmail(profile.email)
                     .switchIfEmpty {

--- a/src/main/resources/db/migration/V8__add_size_table.sql
+++ b/src/main/resources/db/migration/V8__add_size_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE size (
+    id BIGSERIAL NOT NULL,
+    design_id bigint NOT NULL REFERENCES design(id),
+    total_length NUMERIC NOT NULL,
+    sleeve_length NUMERIC NOT NULL,
+    shoulder_width NUMERIC NOT NULL,
+    bottom_width NUMERIC NOT NULL,
+    armhole_depth NUMERIC NOT NULL,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE design DROP COLUMN IF EXISTS total_length;
+ALTER TABLE design DROP COLUMN IF EXISTS sleeve_length;
+ALTER TABLE design DROP COLUMN IF EXISTS shoulder_width;
+ALTER TABLE design DROP COLUMN IF EXISTS bottom_width;
+ALTER TABLE design DROP COLUMN IF EXISTS armhole_depth;
+
+DELETE FROM technique;
+DELETE FROM design;

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/auth/LoginRouterTest.kt
@@ -133,8 +133,7 @@ class LoginRouterTest {
 
         val result = webClientWithMockOAuthHelper
             .get()
-            .uri {
-                uriBuilder ->
+            .uri { uriBuilder ->
                 uriBuilder
                     .path("/auth/google/authorized")
                     .queryParam("code", "MOCK_CODE")
@@ -178,8 +177,7 @@ class LoginRouterTest {
 
         val result = webClientWithMockOAuthHelper
             .get()
-            .uri {
-                uriBuilder ->
+            .uri { uriBuilder ->
                 uriBuilder
                     .path("/auth/google/authorized")
                     .queryParam("code", "MOCK_CODE")
@@ -194,8 +192,7 @@ class LoginRouterTest {
         assert(tokenDecoder.getKnitterId(result.payload.token) == newKnitterId)
 
         verify(repository).create(
-            argThat {
-                param ->
+            argThat { param ->
                 assert(param.id == null)
                 assert(param.email == "new@email.com")
                 assert(param.name == "Jessica Mars")

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -134,8 +134,7 @@ class DesignRouterTest {
 
         assertThat(response.payload.id).isEqualTo(createdDesign.id)
         verify(repository).createDesign(
-            argThat {
-                design ->
+            argThat { design ->
                 assert(
                     design.knitterId == createdDesign.knitterId &&
                         design.name == createdDesign.name &&

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -121,14 +121,12 @@ class DesignsRouterTest {
         )
         verify(repository).getDesignsByKnitterId(
             argThat { param -> param == WebTestClientHelper.AUTHORIZED_KNITTER_ID },
-            argThat {
-                param ->
+            argThat { param ->
                 assert(param.after == null)
                 assert(param.count == 10)
                 true
             },
-            argThat {
-                param ->
+            argThat { param ->
                 assert(param.column == "id")
                 assert(param.direction == SortDirection.DESC)
                 true

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -142,12 +142,10 @@ class ProductRouterTest {
                         product.content == createdProduct.content &&
                         product.inputStatus == createdProduct.inputStatus
                 )
-                product.tags.mapIndexed {
-                    index, tag ->
+                product.tags.mapIndexed { index, tag ->
                     assert(createdProduct.tags[index].name == tag.name)
                 }
-                product.items.mapIndexed {
-                    index, item ->
+                product.items.mapIndexed { index, item ->
                     assert(createdProduct.items[index].itemId == item.itemId)
                 }
                 true
@@ -484,14 +482,12 @@ class ProductRouterTest {
         assertThat(payload[2].id).isEqualTo(2)
         verify(repository).getProductsByKnitterId(
             argThat { param -> param == WebTestClientHelper.AUTHORIZED_KNITTER_ID },
-            argThat {
-                param ->
+            argThat { param ->
                 assert(param.after == null)
                 assert(param.count == 10)
                 true
             },
-            argThat {
-                param ->
+            argThat { param ->
                 assert(param.column == "id")
                 assert(param.direction == SortDirection.DESC)
                 true

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductResponse.kt
@@ -4,14 +4,12 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProductResponse
 
 fun GetMyProductResponse.like(other: GetMyProductResponse): Boolean {
     if (this === other) return true
-    tags.mapIndexed {
-        index, tag ->
+    tags.mapIndexed { index, tag ->
         if (other.tags[index] != tag) {
             return false
         }
     }
-    itemIds.mapIndexed {
-        index, item ->
+    itemIds.mapIndexed { index, item ->
         if (other.itemIds[index] != item) {
             return false
         }

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductsResponse.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/GetMyProductsResponse.kt
@@ -4,8 +4,7 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProductsResponse
 
 fun GetMyProductsResponse.like(other: GetMyProductsResponse): Boolean {
     if (this === other) return true
-    tags.mapIndexed {
-        index, tag ->
+    tags.mapIndexed { index, tag ->
         if (other.tags[index] != tag) {
             return false
         }

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Product.kt
@@ -4,14 +4,12 @@ import com.kroffle.knitting.domain.product.entity.Product
 
 fun Product.like(other: Product): Boolean {
     if (this === other) return true
-    tags.mapIndexed {
-        index, tag ->
+    tags.mapIndexed { index, tag ->
         if (other.tags[index].name != tag.name) {
             return false
         }
     }
-    items.mapIndexed {
-        index, item ->
+    items.mapIndexed { index, item ->
         if (other.items[index].itemId != item.itemId) {
             return false
         }


### PR DESCRIPTION
## PR 제안 사유
도안이 너무 많은 데이터를 들고 있고, 추후에는 도안별로 다른 형태의 사이즈를 가지고 갈 것이기 때문에 사이즈 정보를 분리합니다.

Resolves #124

## 주요 변경 기록
- design entity class에서 size 관련 컬럼 및 필드 제거
- entity -> domain, domain -> entity 컨버팅 메서드 수정
- 사이즈 테이블 추가
