### PR TITLE
feat: ExceptionHelper 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 ## Structure
 
 ```
-^ - pure
+^ - common
 | - domain
 | - usecase
 | - controller
 | - infra
 dependency flow
 ```
-- pure: 코틀린 / java 순수 utils, **외부 라이브러리에 의존하면 안 됨**
+- common: 코틀린 / java 순수 utils, **외부 라이브러리에 의존하면 안 됨**
 - domain: 도메인 로직 담당
 - usecase: 응용 계층, 도메인 레이어에서 제공하는 기능을 통해 비즈니스 로직 구현
 - controller: HTTP 요청 처리

--- a/src/main/kotlin/com/kroffle/knitting/common/exception/BaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/common/exception/BaseException.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.pure.exception
+package com.kroffle.knitting.common.exception
 
 abstract class BaseException(override val message: String) : Exception(message) {
     abstract val httpStatus: HttpStatus

--- a/src/main/kotlin/com/kroffle/knitting/common/exception/ExceptionLayer.kt
+++ b/src/main/kotlin/com/kroffle/knitting/common/exception/ExceptionLayer.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.pure.exception
+package com.kroffle.knitting.common.exception
 
 enum class ExceptionLayer {
     DOMAIN,

--- a/src/main/kotlin/com/kroffle/knitting/common/exception/HttpStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/common/exception/HttpStatus.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.pure.exception
+package com.kroffle.knitting.common.exception
 
 enum class HttpStatus(val code: Int) {
     BAD_REQUEST(400),

--- a/src/main/kotlin/com/kroffle/knitting/common/extensions/LocalDatetime.kt
+++ b/src/main/kotlin/com/kroffle/knitting/common/extensions/LocalDatetime.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.pure.extensions
+package com.kroffle.knitting.common.extensions
 
 import java.time.LocalDateTime
 import java.time.ZoneId

--- a/src/main/kotlin/com/kroffle/knitting/controller/ControllerException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/ControllerException.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.controller
 
-import com.kroffle.knitting.pure.exception.BaseException
-import com.kroffle.knitting.pure.exception.ExceptionLayer
-import com.kroffle.knitting.pure.exception.HttpStatus
+import com.kroffle.knitting.common.exception.BaseException
+import com.kroffle.knitting.common.exception.ExceptionLayer
+import com.kroffle.knitting.common.exception.HttpStatus
 
 open class ControllerException(
     override val message: String,

--- a/src/main/kotlin/com/kroffle/knitting/controller/ControllerException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/ControllerException.kt
@@ -1,0 +1,12 @@
+package com.kroffle.knitting.controller
+
+import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.pure.exception.ExceptionLayer
+import com.kroffle.knitting.pure.exception.HttpStatus
+
+open class ControllerException(
+    override val message: String,
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+) : BaseException(message = message) {
+    override val layer: ExceptionLayer = ExceptionLayer.CONTROLLER
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -31,8 +31,8 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
             ?: return Mono.error(AuthorizationHeaderRequired())
         return try {
             Mono.just(tokenDecoder.getKnitterId(token))
-        } catch (e: Exception) {
-            Mono.error(e)
+        } catch (error: Exception) {
+            Mono.error(error)
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -1,14 +1,12 @@
 package com.kroffle.knitting.controller.filter.auth
 
-import com.kroffle.knitting.controller.filter.auth.exception.TokenDecodeException
+import com.kroffle.knitting.controller.filter.auth.exception.AuthorizationHeaderRequired
+import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
@@ -30,11 +28,11 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
 
     private fun getAuthorization(headers: HttpHeaders): Mono<Long> {
         val token = resolveToken(headers)
-            ?: return Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, "Header is Empty"))
+            ?: return Mono.error(AuthorizationHeaderRequired())
         return try {
             Mono.just(tokenDecoder.getKnitterId(token))
-        } catch (e: TokenDecodeException) {
-            Mono.error(ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message))
+        } catch (e: Exception) {
+            Mono.error(e)
         }
     }
 
@@ -44,18 +42,9 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
             return chain.filter(exchange)
         }
         return getAuthorization(headers = exchange.request.headers)
-            .doOnError { error ->
-                val message = error.message
-                if (message != null) {
-                    val byteMessages = message.toByteArray()
-                    val buffer = exchange.response.bufferFactory().wrap(byteMessages)
-                    exchange.response.writeWith(Flux.just(buffer))
-                }
-            }.doOnSuccess {
-                exchange.attributes["knitterId"] = it
-            }.then(
-                chain.filter(exchange)
-            )
+            .doOnError { error -> ExceptionHelper.raiseException(error) }
+            .doOnSuccess { exchange.attributes["knitterId"] = it }
+            .then(chain.filter(exchange))
     }
 
     interface TokenDecoder {

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/exception/AuthorizationHeaderRequired.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/exception/AuthorizationHeaderRequired.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.controller.filter.auth.exception
+
+import com.kroffle.knitting.controller.ControllerException
+
+class AuthorizationHeaderRequired : ControllerException(message = "Authorization header is required")

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/exception/TokenDecodeException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/exception/TokenDecodeException.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.controller.filter.auth.exception
-
-open class TokenDecodeException(message: String) : Exception(message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -2,8 +2,9 @@ package com.kroffle.knitting.controller.handler.auth
 
 import com.kroffle.knitting.controller.handler.auth.dto.AuthorizedResponse
 import com.kroffle.knitting.controller.handler.auth.dto.RefreshTokenResponse
-import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import com.kroffle.knitting.controller.handler.auth.exception.NotFoundCode
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.usecase.auth.AuthService
 import org.springframework.stereotype.Component
@@ -20,8 +21,8 @@ class GoogleLogInHandler(private val authService: AuthService) {
 
     fun authorized(req: ServerRequest): Mono<ServerResponse> {
         val code = req.queryParam("code")
-        if (code.isEmpty) {
-            throw Unauthorized("code is required")
+        if (code.isEmpty || code.get().isBlank()) {
+            ExceptionHelper.raiseException(NotFoundCode())
         }
         return authService
             .authorize(code.get())

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/exception/NotFoundCode.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/exception/NotFoundCode.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.controller.handler.auth.exception
+
+import com.kroffle.knitting.controller.ControllerException
+
+class NotFoundCode : ControllerException(message = "code is required")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -5,6 +5,7 @@ import com.kroffle.knitting.controller.handler.design.dto.NewDesignRequest
 import com.kroffle.knitting.controller.handler.design.dto.NewDesignResponse
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.domain.design.value.Gauge
@@ -72,11 +73,9 @@ class DesignHandler(private val service: DesignService) {
                     )
                 )
             }
-            .map {
-                NewDesignResponse(id = it.id!!)
-            }.flatMap {
-                ResponseHelper.makeJsonResponse(it)
-            }
+            .doOnError { ExceptionHelper.raiseException(it) }
+            .map { NewDesignResponse(id = it.id!!) }
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
     }
 
     fun getMyDesigns(req: ServerRequest): Mono<ServerResponse> {
@@ -90,6 +89,7 @@ class DesignHandler(private val service: DesignService) {
                     Sort("id", SortDirection.DESC),
                 )
             )
+            .doOnError { ExceptionHelper.raiseException(it) }
             .map { design ->
                 MyDesign(
                     id = design.id!!,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/BadRequest.kt
@@ -1,8 +1,0 @@
-package com.kroffle.knitting.controller.handler.exception
-
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
-
-open class BadRequest(
-    message: String? = "Unknown exception raised"
-) : ResponseStatusException(HttpStatus.BAD_REQUEST, message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/EmptyBodyException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/EmptyBodyException.kt
@@ -1,3 +1,5 @@
 package com.kroffle.knitting.controller.handler.exception
 
-class EmptyBodyException : BadRequest("Body is required")
+import com.kroffle.knitting.controller.ControllerException
+
+class EmptyBodyException : ControllerException(message = "Body is required")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/Unauthorized.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/exception/Unauthorized.kt
@@ -1,6 +1,0 @@
-package com.kroffle.knitting.controller.handler.exception
-
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
-
-class Unauthorized(message: String) : ResponseStatusException(HttpStatus.UNAUTHORIZED, message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
@@ -3,14 +3,12 @@ package com.kroffle.knitting.controller.handler.helper.auth
 import com.kroffle.knitting.controller.handler.helper.auth.exception.KnitterIdRequired
 import org.springframework.web.reactive.function.server.ServerRequest
 
-class AuthHelper {
-    companion object {
-        fun getKnitterId(request: ServerRequest): Long {
-            val knitterId = request.attribute("knitterId")
-            if (knitterId.isEmpty) {
-                throw KnitterIdRequired()
-            }
-            return knitterId.get() as Long
+object AuthHelper {
+    fun getKnitterId(request: ServerRequest): Long {
+        val knitterId = request.attribute("knitterId")
+        if (knitterId.isEmpty) {
+            throw KnitterIdRequired()
         }
+        return knitterId.get() as Long
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/AuthHelper.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.auth
 
-import com.kroffle.knitting.controller.handler.exception.Unauthorized
+import com.kroffle.knitting.controller.handler.helper.auth.exception.KnitterIdRequired
 import org.springframework.web.reactive.function.server.ServerRequest
 
 class AuthHelper {
@@ -8,7 +8,7 @@ class AuthHelper {
         fun getKnitterId(request: ServerRequest): Long {
             val knitterId = request.attribute("knitterId")
             if (knitterId.isEmpty) {
-                throw Unauthorized("knitterId is required")
+                throw KnitterIdRequired()
             }
             return knitterId.get() as Long
         }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/exception/KnitterIdRequired.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/exception/KnitterIdRequired.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.auth.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.controller.ControllerException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class KnitterIdRequired : ControllerException(message = "knitterId is required", HttpStatus.FORBIDDEN)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/exception/KnitterIdRequired.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/auth/exception/KnitterIdRequired.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.controller.handler.helper.auth.exception
+
+import com.kroffle.knitting.controller.ControllerException
+import com.kroffle.knitting.pure.exception.HttpStatus
+
+class KnitterIdRequired : ControllerException(message = "knitterId is required", HttpStatus.FORBIDDEN)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/BaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/BaseException.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.exception
 
-import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.common.exception.BaseException
 import org.springframework.web.server.ResponseStatusException
 
 fun BaseException.to(): ResponseStatusException =

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/BaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/BaseException.kt
@@ -1,0 +1,7 @@
+package com.kroffle.knitting.controller.handler.helper.exception
+
+import com.kroffle.knitting.pure.exception.BaseException
+import org.springframework.web.server.ResponseStatusException
+
+fun BaseException.to(): ResponseStatusException =
+    ResponseStatusException(this.httpStatus.to(), this.message)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/ExceptionHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/ExceptionHelper.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.exception
 
-import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.common.exception.BaseException
 import org.springframework.web.server.ResponseStatusException
 
 object ExceptionHelper {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/ExceptionHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/ExceptionHelper.kt
@@ -1,0 +1,18 @@
+package com.kroffle.knitting.controller.handler.helper.exception
+
+import com.kroffle.knitting.pure.exception.BaseException
+import org.springframework.web.server.ResponseStatusException
+
+object ExceptionHelper {
+    private fun convertException(exception: Throwable): ResponseStatusException =
+        if (exception is BaseException) {
+            exception.to()
+        } else {
+            UnknownException().to()
+        }
+
+    fun raiseException(exception: Throwable) {
+        val statusException = convertException(exception)
+        throw statusException
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/HttpStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/HttpStatus.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.exception
 
-import com.kroffle.knitting.pure.exception.HttpStatus
+import com.kroffle.knitting.common.exception.HttpStatus
 import org.springframework.http.HttpStatus as SpringHttpStatus
 
 fun HttpStatus.to(): SpringHttpStatus {

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/HttpStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/HttpStatus.kt
@@ -1,0 +1,14 @@
+package com.kroffle.knitting.controller.handler.helper.exception
+
+import com.kroffle.knitting.pure.exception.HttpStatus
+import org.springframework.http.HttpStatus as SpringHttpStatus
+
+fun HttpStatus.to(): SpringHttpStatus {
+    return when (this) {
+        HttpStatus.BAD_REQUEST -> SpringHttpStatus.BAD_REQUEST
+        HttpStatus.UNAUTHORIZED -> SpringHttpStatus.UNAUTHORIZED
+        HttpStatus.FORBIDDEN -> SpringHttpStatus.FORBIDDEN
+        HttpStatus.NOT_FOUND -> SpringHttpStatus.NOT_FOUND
+        HttpStatus.INTERNAL_SERVER_ERROR -> SpringHttpStatus.INTERNAL_SERVER_ERROR
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/UnknownException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/UnknownException.kt
@@ -1,0 +1,9 @@
+package com.kroffle.knitting.controller.handler.helper.exception
+
+import com.kroffle.knitting.controller.ControllerException
+import com.kroffle.knitting.pure.exception.HttpStatus
+
+class UnknownException : ControllerException(
+    message = "Unknown exception raised",
+    httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/UnknownException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/exception/UnknownException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.controller.handler.helper.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.controller.ControllerException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class UnknownException : ControllerException(
     message = "Unknown exception raised",

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -25,7 +25,7 @@ class PaginationHelper {
         fun getPagingFromRequest(req: ServerRequest): Paging {
             try {
                 return Paging(after = getAfter(req), count = getCount(req))
-            } catch (e: IllegalArgumentException) {
+            } catch (error: IllegalArgumentException) {
                 throw InvalidPagingParameter()
             }
         }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.controller.handler.helper.pagination
 
-import com.kroffle.knitting.controller.handler.exception.BadRequest
+import com.kroffle.knitting.controller.handler.helper.pagination.exception.InvalidPagingParameter
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import org.springframework.web.reactive.function.server.ServerRequest
 
@@ -26,7 +26,7 @@ class PaginationHelper {
             try {
                 return Paging(after = getAfter(req), count = getCount(req))
             } catch (e: IllegalArgumentException) {
-                throw BadRequest(e.message ?: "Invalid paging parameter")
+                throw InvalidPagingParameter()
             }
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/exception/InvalidPagingParameter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/exception/InvalidPagingParameter.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.controller.handler.helper.pagination.exception
+
+import com.kroffle.knitting.controller.ControllerException
+
+class InvalidPagingParameter : ControllerException(message = "Invalid paging parameter")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/ResponseHelper.kt
@@ -7,39 +7,37 @@ import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
-class ResponseHelper {
+object ResponseHelper {
     private class Response<T>(
         val payload: T,
         val meta: MetaData,
     )
 
-    companion object {
-        private fun makeKnittingResponse(payload: ObjectPayload): Response<ObjectPayload> =
-            Response(
-                payload = payload,
-                meta = MetaData(),
-            )
+    private fun makeKnittingResponse(payload: ObjectPayload): Response<ObjectPayload> =
+        Response(
+            payload = payload,
+            meta = MetaData(),
+        )
 
-        private fun makeKnittingResponse(data: List<ListItemPayload>):
-            Response<List<ListItemPayload>> {
-                val metaData = if (data.isEmpty()) {
-                    MetaData()
-                } else {
-                    MetaData(lastCursor = data.last().getCursor())
-                }
-                return Response(data, metaData)
+    private fun makeKnittingResponse(data: List<ListItemPayload>):
+        Response<List<ListItemPayload>> {
+            val metaData = if (data.isEmpty()) {
+                MetaData()
+            } else {
+                MetaData(lastCursor = data.last().getCursor())
             }
-
-        fun makeJsonResponse(data: ObjectPayload): Mono<ServerResponse> {
-            return ServerResponse.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(makeKnittingResponse(data))
+            return Response(data, metaData)
         }
 
-        fun makeJsonResponse(data: List<ListItemPayload>): Mono<ServerResponse> {
-            return ServerResponse.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(makeKnittingResponse(data))
-        }
+    fun makeJsonResponse(data: ObjectPayload): Mono<ServerResponse> {
+        return ServerResponse.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(makeKnittingResponse(data))
+    }
+
+    fun makeJsonResponse(data: List<ListItemPayload>): Mono<ServerResponse> {
+        return ServerResponse.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(makeKnittingResponse(data))
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
@@ -40,7 +40,7 @@ class MyselfHandler(
                 ResponseHelper
                     .makeJsonResponse(
                         SalesSummaryResponse(
-                            numberOfProductsOnSales = it.toInt(),
+                            numberOfProductsOnSales = it,
                             numberOfProductsSold = 0,
                         )
                     )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummaryResponse.kt
@@ -5,7 +5,7 @@ import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayloa
 
 data class SalesSummaryResponse(
     @JsonProperty("number_of_products_on_sales")
-    val numberOfProductsOnSales: Int,
+    val numberOfProductsOnSales: Long,
     @JsonProperty("number_of_products_sold")
-    val numberOfProductsSold: Int,
+    val numberOfProductsSold: Long,
 ) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.controller.handler.product
 
-import com.kroffle.knitting.controller.handler.exception.BadRequest
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.controller.handler.product.dto.EditProductContentRequest
@@ -60,6 +60,7 @@ class ProductHandler(private val productService: ProductService) {
             }
 
         return product
+            .doOnError { ExceptionHelper.raiseException(it) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -86,7 +87,7 @@ class ProductHandler(private val productService: ProductService) {
             }
 
         return product
-            .onErrorResume { Mono.error(BadRequest(it.message)) }
+            .doOnError { ExceptionHelper.raiseException(it) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -111,7 +112,7 @@ class ProductHandler(private val productService: ProductService) {
                 )
             }
         return product
-            .onErrorResume { Mono.error(BadRequest(it.message)) }
+            .doOnError { ExceptionHelper.raiseException(it) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -131,7 +132,7 @@ class ProductHandler(private val productService: ProductService) {
                 )
             )
         return product
-            .onErrorResume { Mono.error(BadRequest(it.message)) }
+            .doOnError { ExceptionHelper.raiseException(it) }
             .flatMap {
                 ResponseHelper
                     .makeJsonResponse(
@@ -168,7 +169,7 @@ class ProductHandler(private val productService: ProductService) {
                 )
 
         return products
-            .onErrorResume { Mono.error(BadRequest(it.message)) }
+            .doOnError { ExceptionHelper.raiseException(it) }
             .map {
                 product ->
                 GetMyProductsResponse(

--- a/src/main/kotlin/com/kroffle/knitting/domain/DomainException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/DomainException.kt
@@ -1,0 +1,10 @@
+package com.kroffle.knitting.domain
+
+import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.pure.exception.ExceptionLayer
+import com.kroffle.knitting.pure.exception.HttpStatus
+
+open class DomainException(override val message: String) : BaseException(message = message) {
+    override val layer: ExceptionLayer = ExceptionLayer.DOMAIN
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+}

--- a/src/main/kotlin/com/kroffle/knitting/domain/DomainException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/DomainException.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.domain
 
-import com.kroffle.knitting.pure.exception.BaseException
-import com.kroffle.knitting.pure.exception.ExceptionLayer
-import com.kroffle.knitting.pure.exception.HttpStatus
+import com.kroffle.knitting.common.exception.BaseException
+import com.kroffle.knitting.common.exception.ExceptionLayer
+import com.kroffle.knitting.common.exception.HttpStatus
 
 open class DomainException(override val message: String) : BaseException(message = message) {
     override val layer: ExceptionLayer = ExceptionLayer.DOMAIN

--- a/src/main/kotlin/com/kroffle/knitting/domain/exception/DomainException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/exception/DomainException.kt
@@ -1,3 +1,0 @@
-package com.kroffle.knitting.domain.exception
-
-open class DomainException(message: String) : Exception(message)

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidDiscountPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidDiscountPrice.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.domain.product.exception
 
-import com.kroffle.knitting.domain.exception.DomainException
+import com.kroffle.knitting.domain.DomainException
 
-class InvalidDiscountPrice : DomainException("discount price must be between 0 and full price")
+class InvalidDiscountPrice : DomainException(message = "discount price must be between 0 and full price")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidFullPrice.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidFullPrice.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.domain.product.exception
 
-import com.kroffle.knitting.domain.exception.DomainException
+import com.kroffle.knitting.domain.DomainException
 
-class InvalidFullPrice : DomainException("full price must be greater than 0")
+class InvalidFullPrice : DomainException(message = "full price must be greater than 0")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidInputStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidInputStatus.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.domain.product.exception
 
-import com.kroffle.knitting.domain.exception.DomainException
+import com.kroffle.knitting.domain.DomainException
 
-class InvalidInputStatus : DomainException("registered product must have content")
+class InvalidInputStatus : DomainException(message = "registered product must have content")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidPeriod.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/InvalidPeriod.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.domain.product.exception
 
-import com.kroffle.knitting.domain.exception.DomainException
+import com.kroffle.knitting.domain.DomainException
 
-class InvalidPeriod : DomainException("end date must be greater than start date")
+class InvalidPeriod : DomainException(message = "end date must be greater than start date")

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/exception/UnableToRegister.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/exception/UnableToRegister.kt
@@ -1,5 +1,5 @@
 package com.kroffle.knitting.domain.product.exception
 
-import com.kroffle.knitting.domain.exception.DomainException
+import com.kroffle.knitting.domain.DomainException
 
-class UnableToRegister : DomainException("unable to register because of domain fields")
+class UnableToRegister : DomainException(message = "unable to register because of domain fields")

--- a/src/main/kotlin/com/kroffle/knitting/infra/InfraException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/InfraException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.infra
 
-import com.kroffle.knitting.pure.exception.BaseException
-import com.kroffle.knitting.pure.exception.ExceptionLayer
+import com.kroffle.knitting.common.exception.BaseException
+import com.kroffle.knitting.common.exception.ExceptionLayer
 
 abstract class InfraException(override val message: String) : BaseException(message = message) {
     override val layer: ExceptionLayer = ExceptionLayer.INFRA

--- a/src/main/kotlin/com/kroffle/knitting/infra/InfraException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/InfraException.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.infra
+
+import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.pure.exception.ExceptionLayer
+
+abstract class InfraException(override val message: String) : BaseException(message = message) {
+    override val layer: ExceptionLayer = ExceptionLayer.INFRA
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenDecoder.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenDecoder.kt
@@ -23,9 +23,9 @@ class TokenDecoder(private val jwtSecretKey: String) : AuthorizationFilter.Token
                 .build()
                 .verify(token)
             return jwt.claims
-        } catch (e: TokenExpiredException) {
+        } catch (error: TokenExpiredException) {
             throw ExpiredTokenException()
-        } catch (e: JWTVerificationException) {
+        } catch (error: JWTVerificationException) {
             throw UnauthorizedTokenException()
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenPublisher.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/TokenPublisher.kt
@@ -2,7 +2,7 @@ package com.kroffle.knitting.infra.jwt
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
-import com.kroffle.knitting.pure.extensions.toDate
+import com.kroffle.knitting.common.extensions.toDate
 import com.kroffle.knitting.usecase.auth.AuthService
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/ExpiredTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/ExpiredTokenException.kt
@@ -1,5 +1,8 @@
 package com.kroffle.knitting.infra.jwt.exception
 
-import com.kroffle.knitting.controller.filter.auth.exception.TokenDecodeException
+import com.kroffle.knitting.infra.InfraException
+import com.kroffle.knitting.pure.exception.HttpStatus
 
-class ExpiredTokenException : TokenDecodeException("Token is expired.")
+class ExpiredTokenException : InfraException(message = "Token is expired.") {
+    override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/ExpiredTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/ExpiredTokenException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.infra.jwt.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.infra.InfraException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class ExpiredTokenException : InfraException(message = "Token is expired.") {
     override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/InvalidBodyTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/InvalidBodyTokenException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.infra.jwt.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.infra.InfraException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class InvalidBodyTokenException : InfraException(message = "Token had invalid body format.") {
     override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/InvalidBodyTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/InvalidBodyTokenException.kt
@@ -1,5 +1,8 @@
 package com.kroffle.knitting.infra.jwt.exception
 
-import com.kroffle.knitting.controller.filter.auth.exception.TokenDecodeException
+import com.kroffle.knitting.infra.InfraException
+import com.kroffle.knitting.pure.exception.HttpStatus
 
-class InvalidBodyTokenException : TokenDecodeException("Token had invalid body format.")
+class InvalidBodyTokenException : InfraException(message = "Token had invalid body format.") {
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/UnauthorizedTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/UnauthorizedTokenException.kt
@@ -1,5 +1,8 @@
 package com.kroffle.knitting.infra.jwt.exception
 
-import com.kroffle.knitting.controller.filter.auth.exception.TokenDecodeException
+import com.kroffle.knitting.infra.InfraException
+import com.kroffle.knitting.pure.exception.HttpStatus
 
-class UnauthorizedTokenException : TokenDecodeException("Token is unauthorized.")
+class UnauthorizedTokenException : InfraException(message = "Token is unauthorized.") {
+    override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/UnauthorizedTokenException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/jwt/exception/UnauthorizedTokenException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.infra.jwt.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.infra.InfraException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class UnauthorizedTokenException : InfraException(message = "Token is unauthorized.") {
     override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/exception/NotFoundEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/exception/NotFoundEntity.kt
@@ -1,3 +1,8 @@
 package com.kroffle.knitting.infra.persistence.exception
 
-class NotFoundEntity(clazz: Class<*>) : Exception("Cannot found ${clazz.name}")
+import com.kroffle.knitting.infra.InfraException
+import com.kroffle.knitting.pure.exception.HttpStatus
+
+class NotFoundEntity(clazz: Class<*>) : InfraException(message = "Cannot found ${clazz.name}") {
+    override val httpStatus: HttpStatus = HttpStatus.NOT_FOUND
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/exception/NotFoundEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/exception/NotFoundEntity.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.infra.persistence.exception
 
+import com.kroffle.knitting.common.exception.HttpStatus
 import com.kroffle.knitting.infra.InfraException
-import com.kroffle.knitting.pure.exception.HttpStatus
 
 class NotFoundEntity(clazz: Class<*>) : InfraException(message = "Cannot found ${clazz.name}") {
     override val httpStatus: HttpStatus = HttpStatus.NOT_FOUND

--- a/src/main/kotlin/com/kroffle/knitting/pure/exception/BaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/pure/exception/BaseException.kt
@@ -1,0 +1,6 @@
+package com.kroffle.knitting.pure.exception
+
+abstract class BaseException(override val message: String) : Exception(message) {
+    abstract val httpStatus: HttpStatus
+    abstract val layer: ExceptionLayer
+}

--- a/src/main/kotlin/com/kroffle/knitting/pure/exception/ExceptionLayer.kt
+++ b/src/main/kotlin/com/kroffle/knitting/pure/exception/ExceptionLayer.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.pure.exception
+
+enum class ExceptionLayer {
+    DOMAIN,
+    USE_CASE,
+    CONTROLLER,
+    INFRA
+}

--- a/src/main/kotlin/com/kroffle/knitting/pure/exception/HttpStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/pure/exception/HttpStatus.kt
@@ -1,0 +1,9 @@
+package com.kroffle.knitting.pure.exception
+
+enum class HttpStatus(val code: Int) {
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    NOT_FOUND(404),
+    FORBIDDEN(403),
+    INTERNAL_SERVER_ERROR(500),
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/UseCaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/UseCaseException.kt
@@ -1,7 +1,7 @@
 package com.kroffle.knitting.usecase
 
-import com.kroffle.knitting.pure.exception.BaseException
-import com.kroffle.knitting.pure.exception.ExceptionLayer
+import com.kroffle.knitting.common.exception.BaseException
+import com.kroffle.knitting.common.exception.ExceptionLayer
 
 abstract class UseCaseException(
     override val message: String,

--- a/src/main/kotlin/com/kroffle/knitting/usecase/UseCaseException.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/UseCaseException.kt
@@ -1,0 +1,10 @@
+package com.kroffle.knitting.usecase
+
+import com.kroffle.knitting.pure.exception.BaseException
+import com.kroffle.knitting.pure.exception.ExceptionLayer
+
+abstract class UseCaseException(
+    override val message: String,
+) : BaseException(message) {
+    override val layer: ExceptionLayer = ExceptionLayer.USE_CASE
+}


### PR DESCRIPTION
## PR 제안 사유

- 기존 exception 처리 로직은 status code가 제대로 분리되지 않고, 
- controller에서 에러를 처리해주는 로직이 중복되고 있었습니다.
- 중복된 코드를 제거하고 상황에 맞게 적절한 http status code를 내려줄 수 있도록 ExceptionHelper를 구현합니다.

Resolves #130 

## 주요 변경 기록
- 올바르지 않은 데이터 타입 수정 (SalesSummaryResponse)
- Helper class들 object로 변경
  - object keyword를 이용하면 싱글턴으로 생성된다고 합니당!
  - 아래 companion object를 뒀던 이유가 싱글턴으로 만들어서 사용하고 싶어서였기 때문에, 더 적절한 방법으로 수정했습다.
- ExceptionHelper 구현 및 해당 Helper class를 이용해서 에러 핸들링하도록 수정
