### PR TITLE
refactor: Value class에서 created_at 제거

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -50,7 +50,7 @@ class ProductHandler(private val productService: ProductService) {
                         representativeImageUrl = body.representativeImageUrl,
                         specifiedSalesStartDate = body.specifiedSalesStartDate,
                         specifiedSalesEndDate = body.specifiedSalesEndDate,
-                        tags = body.tags.map { ProductTag(it, null) },
+                        tags = body.tags.map { ProductTag(it) },
                         items = body.designIds.map { ProductItem.create(it, ProductItemType.DESIGN) },
                     )
                 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -51,7 +51,7 @@ class ProductHandler(private val productService: ProductService) {
                         specifiedSalesStartDate = body.specifiedSalesStartDate,
                         specifiedSalesEndDate = body.specifiedSalesEndDate,
                         tags = body.tags.map { ProductTag(it, null) },
-                        items = body.designIds.map { ProductItem.create(it, null, ProductItemType.DESIGN) },
+                        items = body.designIds.map { ProductItem.create(it, ProductItemType.DESIGN) },
                     )
                 )
             }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
@@ -1,12 +1,8 @@
 package com.kroffle.knitting.domain.product.value
 
 import com.kroffle.knitting.domain.product.enum.ProductItemType
-import java.time.OffsetDateTime
 
-class DesignProductItem(
-    itemId: Long,
-    createdAt: OffsetDateTime?,
-) : ProductItem(itemId, createdAt) {
+class DesignProductItem(itemId: Long) : ProductItem(itemId) {
     override val type: ProductItemType
         get() = ProductItemType.DESIGN
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
@@ -1,12 +1,8 @@
 package com.kroffle.knitting.domain.product.value
 
 import com.kroffle.knitting.domain.product.enum.ProductItemType
-import java.time.OffsetDateTime
 
-class GoodsProductItem(
-    itemId: Long,
-    createdAt: OffsetDateTime?,
-) : ProductItem(itemId, createdAt) {
+class GoodsProductItem(itemId: Long) : ProductItem(itemId) {
     override val type: ProductItemType
         get() = ProductItemType.GOODS
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
@@ -1,19 +1,15 @@
 package com.kroffle.knitting.domain.product.value
 
 import com.kroffle.knitting.domain.product.enum.ProductItemType
-import java.time.OffsetDateTime
 
-abstract class ProductItem(
-    val itemId: Long,
-    val createdAt: OffsetDateTime?,
-) {
+abstract class ProductItem(val itemId: Long) {
     abstract val type: ProductItemType
 
     companion object {
-        fun create(itemId: Long, createdAt: OffsetDateTime?, type: ProductItemType): ProductItem {
+        fun create(itemId: Long, type: ProductItemType): ProductItem {
             return when (type) {
-                ProductItemType.DESIGN -> DesignProductItem(itemId, createdAt)
-                ProductItemType.GOODS -> GoodsProductItem(itemId, createdAt)
+                ProductItemType.DESIGN -> DesignProductItem(itemId)
+                ProductItemType.GOODS -> GoodsProductItem(itemId)
             }
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductTag.kt
@@ -1,8 +1,3 @@
 package com.kroffle.knitting.domain.product.value
 
-import java.time.OffsetDateTime
-
-data class ProductTag(
-    val name: String,
-    val createdAt: OffsetDateTime?,
-)
+data class ProductTag(val name: String)

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
@@ -5,7 +5,6 @@ import com.kroffle.knitting.domain.product.enum.ProductItemType
 import com.kroffle.knitting.domain.product.value.ProductItem
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
-import java.time.OffsetDateTime
 
 @Table("product_item")
 class ProductItemEntity(
@@ -13,9 +12,8 @@ class ProductItemEntity(
     private val productId: Long,
     private val itemId: Long,
     private val type: ProductItemType,
-    private val createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) {
-    fun toItem() = ProductItem.create(itemId, createdAt, type)
+    fun toItem() = ProductItem.create(itemId, type)
     fun getForeignKey(): Long = productId
 }
 
@@ -25,6 +23,5 @@ fun Product.toProductItemEntities(productId: Long): List<ProductItemEntity> =
             productId = this.id ?: productId,
             itemId = item.itemId,
             type = item.type,
-            createdAt = item.createdAt ?: OffsetDateTime.now(),
         )
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductTagEntity.kt
@@ -4,19 +4,14 @@ import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.value.ProductTag
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
-import java.time.OffsetDateTime
 
 @Table("product_tag")
 class ProductTagEntity(
     @Id private var id: Long? = null,
     private val productId: Long,
     private val name: String,
-    private val createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) {
-    fun toTag() = ProductTag(
-        name = name,
-        createdAt = createdAt,
-    )
+    fun toTag() = ProductTag(name = name)
     fun getForeignKey(): Long = productId
 }
 
@@ -26,6 +21,5 @@ fun Product.toProductTagEntities(productId: Long): List<ProductTagEntity> =
             id = null,
             productId = this.id ?: productId,
             name = tag.name,
-            createdAt = tag.createdAt ?: OffsetDateTime.now(),
         )
     }

--- a/src/main/resources/db/migration/V9__remove_created_at_from_value.sql
+++ b/src/main/resources/db/migration/V9__remove_created_at_from_value.sql
@@ -1,0 +1,2 @@
+ALTER TABLE product_tag DROP COLUMN IF EXISTS created_at;
+ALTER TABLE product_item DROP COLUMN IF EXISTS created_at;

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -87,11 +87,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag("서술형도안", today),
-                ProductTag("초보자용", today),
+                ProductTag("서술형도안"),
+                ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItemType.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -164,11 +164,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag("서술형도안", today),
-                ProductTag("초보자용", today),
+                ProductTag("서술형도안"),
+                ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItemType.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -182,8 +182,8 @@ class ProductRouterTest {
                 representativeImageUrl = "http://test2.knitting.com/image.jpg",
                 specifiedSalesStartDate = tomorrow.toLocalDate(),
                 specifiedSalesEndDate = null,
-                tags = listOf(ProductTag("서술형도안", today)),
-                items = listOf(ProductItem.create(2, today, ProductItemType.DESIGN))
+                tags = listOf(ProductTag("서술형도안")),
+                items = listOf(ProductItem.create(2, ProductItemType.DESIGN))
             )
         given(repository.getProductByIdAndKnitterId(any(), any()))
             .willReturn(Mono.just(targetProduct))
@@ -268,11 +268,11 @@ class ProductRouterTest {
             content = null,
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag("서술형도안", today),
-                ProductTag("초보자용", today),
+                ProductTag("서술형도안"),
+                ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItemType.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,
@@ -335,11 +335,11 @@ class ProductRouterTest {
             content = "이번에는 초보탈출 패키지를 준비해봤어요.",
             inputStatus = InputStatus.DRAFT,
             tags = listOf(
-                ProductTag("서술형도안", today),
-                ProductTag("초보자용", today),
+                ProductTag("서술형도안"),
+                ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, today, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItemType.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/MyDesign.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/MyDesign.kt
@@ -9,5 +9,5 @@ fun MyDesign.Response.like(other: MyDesign.Response): Boolean {
         yarn == other.yarn &&
         coverImageUrl == other.coverImageUrl &&
         tags == other.tags &&
-        createdAt == other.createdAt
+        createdAt.isEqual(other.createdAt)
 }


### PR DESCRIPTION
## PR 제안 사유
- value class에서 created_at을 관리할 필요가 없기 때문에 제거합니다.

Resolves #139 

## 주요 변경 기록

- product_tag, product_item에 남아있는 created_at을 제거합니다.
- OffsetDateTime으로 바꾸면서 tz로 인해 깨지는 테스트가 있어서 함께 수정해줍니다.
