### PR TITLE
refactor: move Money class into product package

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -12,9 +12,9 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.enum.ProductItemType
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.product.ProductService

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -7,9 +7,9 @@ import com.kroffle.knitting.domain.product.exception.InvalidFullPrice
 import com.kroffle.knitting.domain.product.exception.InvalidInputStatus
 import com.kroffle.knitting.domain.product.exception.InvalidPeriod
 import com.kroffle.knitting.domain.product.exception.UnableToRegister
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import java.time.LocalDate
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/Money.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/Money.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.domain.value
+package com.kroffle.knitting.domain.product.value
 
 class Money(val value: Int) {
     operator fun compareTo(money: Money): Int =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
@@ -2,9 +2,9 @@ package com.kroffle.knitting.infra.persistence.product.entity
 
 import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/EditProductPackageData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/EditProductPackageData.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.usecase.product.dto
 
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import java.time.LocalDate
 
 data class EditProductPackageData(

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -10,9 +10,9 @@ import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.domain.product.enum.ProductItemType
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper

--- a/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
@@ -1,9 +1,9 @@
 package com.kroffle.knitting.helper.dto
 
 import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
-import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.WebTestClientHelper
 import java.time.LocalDate
 import java.time.OffsetDateTime

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Money.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Money.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.helper.extension
 
-import com.kroffle.knitting.domain.value.Money
+import com.kroffle.knitting.domain.product.value.Money
 
 fun Money.like(other: Money): Boolean {
     if (this === other) return true


### PR DESCRIPTION
## PR 제안 사유
- Money class를 product pacakage 하위로 이동시킵니다.
- 기존에는 Money를 Product와 Design에서 공통으로 써서 상위에 두었는데 이제는 Product에서만 쓰기 때문에 이동시킵니다.

