### PR TITLE
refactor: enum 대이동

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
@@ -2,18 +2,16 @@ package com.kroffle.knitting.controller.handler.design.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
-import com.kroffle.knitting.domain.design.enum.SizeUnitType
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.design.value.Length
 
 object NewDesign {
     data class Request(
         val name: String,
         @JsonProperty("design_type")
-        val designType: DesignType,
+        val designType: Design.DesignType,
         @JsonProperty("pattern_type")
-        val patternType: PatternType,
+        val patternType: Design.PatternType,
         val stitches: Double,
         val rows: Double,
         val size: NewDesignSize,
@@ -23,14 +21,14 @@ object NewDesign {
         val pattern: String,
         val description: String,
         @JsonProperty("target_level")
-        val targetLevel: LevelType,
+        val targetLevel: Design.LevelType,
         @JsonProperty("cover_image_url")
         val coverImageUrl: String,
         val techniques: List<String>,
     ) {
         data class NewDesignSize(
             @JsonProperty("size_unit")
-            val sizeUnit: SizeUnitType = SizeUnitType.Cm,
+            val sizeUnit: Length.Unit = Length.Unit.Cm,
             @JsonProperty("total_length")
             val totalLength: Double,
             @JsonProperty("sleeve_length")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -11,7 +11,6 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProduct
 import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.enum.ProductItemType
 import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
@@ -51,7 +50,7 @@ class ProductHandler(private val productService: ProductService) {
                         specifiedSalesStartDate = body.specifiedSalesStartDate,
                         specifiedSalesEndDate = body.specifiedSalesEndDate,
                         tags = body.tags.map { ProductTag(it) },
-                        items = body.designIds.map { ProductItem.create(it, ProductItemType.DESIGN) },
+                        items = body.designIds.map { ProductItem.create(it, ProductItem.Type.DESIGN) },
                     )
                 )
             }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProduct.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProduct.kt
@@ -2,7 +2,7 @@ package com.kroffle.knitting.controller.handler.product.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -23,7 +23,7 @@ object GetMyProduct {
         val tags: List<String>,
         val content: String?,
         @JsonProperty("input_status")
-        val inputStatus: InputStatus,
+        val inputStatus: Product.InputStatus,
         val itemIds: List<Long>,
         @JsonProperty("created_at")
         val createdAt: OffsetDateTime?,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProducts.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProducts.kt
@@ -2,7 +2,7 @@ package com.kroffle.knitting.controller.handler.product.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -22,7 +22,7 @@ object GetMyProducts {
         val specifiedSalesEndDate: LocalDate?,
         val tags: List<String>,
         @JsonProperty("input_status")
-        val inputStatus: InputStatus,
+        val inputStatus: Product.InputStatus,
         @JsonProperty("updated_at")
         val updatedAt: OffsetDateTime?,
     ) : ListItemPayload {

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -1,8 +1,5 @@
 package com.kroffle.knitting.domain.design.entity
 
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
@@ -27,6 +24,23 @@ class Design(
     val techniques: List<Technique>,
     val createdAt: OffsetDateTime?,
 ) {
+    enum class DesignType(val code: Int, val tag: String) {
+        Sweater(1, "니트"),
+    }
+
+    enum class PatternType(val code: Int, val tag: String) {
+        Text(1, "서술형도안"),
+        Image(2, "이미지도안"),
+        Video(3, "영상도안"),
+    }
+
+    enum class LevelType {
+        PERSON_BY_PERSON,
+        EASY,
+        NORMAL,
+        HARD
+    }
+
     companion object {
         fun new(
             knitterId: Long,

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/enum/DesignType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/enum/DesignType.kt
@@ -1,5 +1,0 @@
-package com.kroffle.knitting.domain.design.enum
-
-enum class DesignType(val code: Int, val tag: String) {
-    Sweater(1, "니트"),
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/enum/LevelType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/enum/LevelType.kt
@@ -1,8 +1,0 @@
-package com.kroffle.knitting.domain.design.enum
-
-enum class LevelType {
-    PERSON_BY_PERSON,
-    EASY,
-    NORMAL,
-    HARD
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/enum/PatternType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/enum/PatternType.kt
@@ -1,7 +1,0 @@
-package com.kroffle.knitting.domain.design.enum
-
-enum class PatternType(val code: Int, val tag: String) {
-    Text(1, "서술형도안"),
-    Image(2, "이미지도안"),
-    Video(3, "영상도안"),
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/enum/SizeUnitType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/enum/SizeUnitType.kt
@@ -1,5 +1,0 @@
-package com.kroffle.knitting.domain.design.enum
-
-enum class SizeUnitType(val code: Int) {
-    Cm(1),
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/value/Length.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/value/Length.kt
@@ -1,9 +1,11 @@
 package com.kroffle.knitting.domain.design.value
 
-import com.kroffle.knitting.domain.design.enum.SizeUnitType
-
-class Length(val value: Double, val unit: SizeUnitType = SizeUnitType.Cm) {
+class Length(val value: Double, val unit: Unit = Unit.Cm) {
     init {
         require(value > 0)
+    }
+
+    enum class Unit(val code: Int) {
+        Cm(1),
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -1,7 +1,5 @@
 package com.kroffle.knitting.domain.product.entity
 
-import com.kroffle.knitting.domain.product.enum.InputStatus
-import com.kroffle.knitting.domain.product.enum.SalesStatus
 import com.kroffle.knitting.domain.product.exception.InvalidDiscountPrice
 import com.kroffle.knitting.domain.product.exception.InvalidFullPrice
 import com.kroffle.knitting.domain.product.exception.InvalidInputStatus
@@ -141,6 +139,17 @@ class Product(
             createdAt,
             OffsetDateTime.now(),
         )
+    }
+
+    enum class InputStatus {
+        DRAFT,
+        REGISTERED
+    }
+
+    enum class SalesStatus {
+        RESERVED,
+        ON_SALES,
+        COMPLETED,
     }
 
     companion object {

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/enum/InputStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/enum/InputStatus.kt
@@ -1,6 +1,0 @@
-package com.kroffle.knitting.domain.product.enum
-
-enum class InputStatus(label: String) {
-    DRAFT("입력 중"),
-    REGISTERED("입력 완료")
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/enum/ProductItemType.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/enum/ProductItemType.kt
@@ -1,6 +1,0 @@
-package com.kroffle.knitting.domain.product.enum
-
-enum class ProductItemType {
-    GOODS,
-    DESIGN
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/enum/SalesStatus.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/enum/SalesStatus.kt
@@ -1,7 +1,0 @@
-package com.kroffle.knitting.domain.product.enum
-
-enum class SalesStatus {
-    RESERVED,
-    ON_SALES,
-    COMPLETED,
-}

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/DesignProductItem.kt
@@ -1,8 +1,6 @@
 package com.kroffle.knitting.domain.product.value
 
-import com.kroffle.knitting.domain.product.enum.ProductItemType
-
 class DesignProductItem(itemId: Long) : ProductItem(itemId) {
-    override val type: ProductItemType
-        get() = ProductItemType.DESIGN
+    override val type: ProductItem.Type
+        get() = ProductItem.Type.DESIGN
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/GoodsProductItem.kt
@@ -1,8 +1,6 @@
 package com.kroffle.knitting.domain.product.value
 
-import com.kroffle.knitting.domain.product.enum.ProductItemType
-
 class GoodsProductItem(itemId: Long) : ProductItem(itemId) {
-    override val type: ProductItemType
-        get() = ProductItemType.GOODS
+    override val type: ProductItem.Type
+        get() = ProductItem.Type.GOODS
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/value/ProductItem.kt
@@ -1,15 +1,18 @@
 package com.kroffle.knitting.domain.product.value
 
-import com.kroffle.knitting.domain.product.enum.ProductItemType
-
 abstract class ProductItem(val itemId: Long) {
-    abstract val type: ProductItemType
+    abstract val type: Type
+
+    enum class Type {
+        GOODS,
+        DESIGN
+    }
 
     companion object {
-        fun create(itemId: Long, type: ProductItemType): ProductItem {
+        fun create(itemId: Long, type: Type): ProductItem {
             return when (type) {
-                ProductItemType.DESIGN -> DesignProductItem(itemId)
-                ProductItemType.GOODS -> GoodsProductItem(itemId)
+                Type.DESIGN -> DesignProductItem(itemId)
+                Type.GOODS -> GoodsProductItem(itemId)
             }
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
@@ -1,9 +1,8 @@
 package com.kroffle.knitting.infra.configuration
 
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.PatternType
-import com.kroffle.knitting.domain.product.enum.InputStatus
-import com.kroffle.knitting.domain.product.enum.ProductItemType
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.product.entity.Product
+import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.infra.configuration.r2dbc.converter.DesignTypeConverter
 import com.kroffle.knitting.infra.configuration.r2dbc.converter.InputStatusConverter
 import com.kroffle.knitting.infra.configuration.r2dbc.converter.PatternTypeConverter
@@ -32,10 +31,10 @@ class R2dbcConfiguration : AbstractR2dbcConfiguration() {
             .username(appProperties.username)
             .password(appProperties.password)
             .database(appProperties.database)
-            .codecRegistrar(EnumCodec.builder().withEnum(DESIGN_TYPE, DesignType::class.java).build())
-            .codecRegistrar(EnumCodec.builder().withEnum(PATTERN_TYPE, PatternType::class.java).build())
-            .codecRegistrar(EnumCodec.builder().withEnum(INPUT_STATUS, InputStatus::class.java).build())
-            .codecRegistrar(EnumCodec.builder().withEnum(PRODUCT_ITEM_TYPE, ProductItemType::class.java).build())
+            .codecRegistrar(EnumCodec.builder().withEnum(DESIGN_TYPE, Design.DesignType::class.java).build())
+            .codecRegistrar(EnumCodec.builder().withEnum(PATTERN_TYPE, Design.PatternType::class.java).build())
+            .codecRegistrar(EnumCodec.builder().withEnum(INPUT_STATUS, Product.InputStatus::class.java).build())
+            .codecRegistrar(EnumCodec.builder().withEnum(PRODUCT_ITEM_TYPE, ProductItem.Type::class.java).build())
             .build()
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/DesignTypeConverter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/DesignTypeConverter.kt
@@ -1,12 +1,12 @@
 package com.kroffle.knitting.infra.configuration.r2dbc.converter
 
-import com.kroffle.knitting.domain.design.enum.DesignType
+import com.kroffle.knitting.domain.design.entity.Design
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 
 @WritingConverter
-class DesignTypeConverter : Converter<DesignType, DesignType> {
-    override fun convert(source: DesignType): DesignType {
+class DesignTypeConverter : Converter<Design.DesignType, Design.DesignType> {
+    override fun convert(source: Design.DesignType): Design.DesignType {
         return source
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/InputStatusConverter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/InputStatusConverter.kt
@@ -1,12 +1,12 @@
 package com.kroffle.knitting.infra.configuration.r2dbc.converter
 
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 
 @WritingConverter
-class InputStatusConverter : Converter<InputStatus, InputStatus> {
-    override fun convert(source: InputStatus): InputStatus {
+class InputStatusConverter : Converter<Product.InputStatus, Product.InputStatus> {
+    override fun convert(source: Product.InputStatus): Product.InputStatus {
         return source
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/PatternTypeConverter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/PatternTypeConverter.kt
@@ -1,12 +1,12 @@
 package com.kroffle.knitting.infra.configuration.r2dbc.converter
 
-import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.domain.design.entity.Design
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 
 @WritingConverter
-class PatternTypeConverter : Converter<PatternType, PatternType> {
-    override fun convert(source: PatternType): PatternType {
+class PatternTypeConverter : Converter<Design.PatternType, Design.PatternType> {
+    override fun convert(source: Design.PatternType): Design.PatternType {
         return source
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/ProductItemTypeConverter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/r2dbc/converter/ProductItemTypeConverter.kt
@@ -1,12 +1,12 @@
 package com.kroffle.knitting.infra.configuration.r2dbc.converter
 
-import com.kroffle.knitting.domain.product.enum.ProductItemType
+import com.kroffle.knitting.domain.product.value.ProductItem
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 
 @WritingConverter
-class ProductItemTypeConverter : Converter<ProductItemType, ProductItemType> {
-    override fun convert(source: ProductItemType): ProductItemType {
+class ProductItemTypeConverter : Converter<ProductItem.Type, ProductItem.Type> {
+    override fun convert(source: ProductItem.Type): ProductItem.Type {
         return source
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -1,9 +1,6 @@
 package com.kroffle.knitting.infra.persistence.design.entity
 
 import com.kroffle.knitting.domain.design.entity.Design
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
@@ -17,8 +14,8 @@ class DesignEntity(
     @Id private var id: Long?,
     private val knitterId: Long,
     private val name: String,
-    private val designType: DesignType,
-    private val patternType: PatternType,
+    private val designType: Design.DesignType,
+    private val patternType: Design.PatternType,
     private val stitches: Double,
     private val rows: Double,
     private val needle: String,
@@ -46,7 +43,7 @@ class DesignEntity(
             extra = this.extra,
             pattern = Pattern(this.pattern),
             description = this.description,
-            targetLevel = LevelType.valueOf(this.targetLevel),
+            targetLevel = Design.LevelType.valueOf(this.targetLevel),
             coverImageUrl = this.coverImageUrl,
             techniques = techniques,
             createdAt = this.createdAt,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/SizeEntity.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.infra.persistence.design.entity
 
 import com.kroffle.knitting.domain.design.entity.Design
-import com.kroffle.knitting.domain.design.enum.SizeUnitType
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Size
 import org.springframework.data.annotation.Id
@@ -29,7 +28,7 @@ class SizeEntity(
     fun getForeignKey() = designId
 
     companion object {
-        private val DEFAULT_UNIT = SizeUnitType.Cm
+        private val DEFAULT_UNIT = Length.Unit.Cm
     }
 }
 

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.infra.persistence.product.entity
 
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
@@ -21,7 +20,7 @@ class ProductEntity(
     private val specifiedSalesStartDate: LocalDate?,
     private val specifiedSalesEndDate: LocalDate?,
     private val content: String?,
-    private val inputStatus: InputStatus,
+    private val inputStatus: Product.InputStatus,
     private val createdAt: OffsetDateTime = OffsetDateTime.now(),
     private val updatedAt: OffsetDateTime = OffsetDateTime.now(),
 ) {

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductItemEntity.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.infra.persistence.product.entity
 
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.enum.ProductItemType
 import com.kroffle.knitting.domain.product.value.ProductItem
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
@@ -11,7 +10,7 @@ class ProductItemEntity(
     @Id private var id: Long? = null,
     private val productId: Long,
     private val itemId: Long,
-    private val type: ProductItemType,
+    private val type: ProductItem.Type,
 ) {
     fun toItem() = ProductItem.create(itemId, type)
     fun getForeignKey(): Long = productId

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/DBProductRepository.kt
@@ -1,13 +1,13 @@
 package com.kroffle.knitting.infra.persistence.product.repository
 
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
 interface DBProductRepository : ReactiveCrudRepository<ProductEntity, Long> {
-    fun findAllByKnitterIdAndInputStatus(knitterId: Long, inputStatus: InputStatus): Flux<ProductEntity>
+    fun findAllByKnitterIdAndInputStatus(knitterId: Long, inputStatus: Product.InputStatus): Flux<ProductEntity>
     fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<ProductEntity>
     fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<ProductEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2dbcProductRepository.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.infra.persistence.product.repository
 
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.enum.InputStatus
 import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.infra.persistence.helper.pagination.PaginationHelper
 import com.kroffle.knitting.infra.persistence.product.entity.ProductEntity
@@ -138,7 +137,7 @@ class R2dbcProductRepository(
     override fun findRegisteredProduct(knitterId: Long): Flux<Product> {
         val products: Flux<ProductEntity> =
             productRepository
-                .findAllByKnitterIdAndInputStatus(knitterId, InputStatus.REGISTERED)
+                .findAllByKnitterIdAndInputStatus(knitterId, Product.InputStatus.REGISTERED)
         return getProductAggregates(products)
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
@@ -1,8 +1,6 @@
 package com.kroffle.knitting.usecase.design.dto
 
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
+import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
@@ -11,8 +9,8 @@ import com.kroffle.knitting.domain.design.value.Technique
 data class CreateDesignData(
     val knitterId: Long,
     val name: String,
-    val designType: DesignType,
-    val patternType: PatternType,
+    val designType: Design.DesignType,
+    val patternType: Design.PatternType,
     val gauge: Gauge,
     val size: Size,
     val needle: String,
@@ -20,7 +18,7 @@ data class CreateDesignData(
     val extra: String?,
     val pattern: Pattern,
     val description: String,
-    val targetLevel: LevelType,
+    val targetLevel: Design.LevelType,
     val coverImageUrl: String,
     val techniques: List<Technique>,
 )

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
 import com.kroffle.knitting.domain.design.entity.Design
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
@@ -68,8 +65,8 @@ class DesignRouterTest {
             id = 1,
             knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
             name = "test",
-            designType = DesignType.Sweater,
-            patternType = PatternType.Text,
+            designType = Design.DesignType.Sweater,
+            patternType = Design.PatternType.Text,
             gauge = Gauge(
                 stitches = 23.5,
                 rows = 25.0,
@@ -86,7 +83,7 @@ class DesignRouterTest {
             extra = null,
             pattern = Pattern("# Step1. 코를 10개 잡습니다."),
             description = "이건 니트를 만드는 서술형 도안입니다.",
-            targetLevel = LevelType.HARD,
+            targetLevel = Design.LevelType.HARD,
             coverImageUrl = "http://test.kroffle.com/image.jpg",
             techniques = listOf(Technique("겉뜨기"), Technique("안뜨기")),
             createdAt = OffsetDateTime.now(),
@@ -96,8 +93,8 @@ class DesignRouterTest {
         val body = objectMapper.writeValueAsString(
             NewDesign.Request(
                 name = "test",
-                designType = DesignType.Sweater,
-                patternType = PatternType.Text,
+                designType = Design.DesignType.Sweater,
+                patternType = Design.PatternType.Text,
                 stitches = 23.5,
                 rows = 25.0,
                 size = NewDesign.Request.NewDesignSize(
@@ -112,7 +109,7 @@ class DesignRouterTest {
                 extra = null,
                 pattern = "# Step1. 코를 10개 잡습니다.",
                 description = "이건 니트를 만드는 서술형 도안입니다.",
-                targetLevel = LevelType.HARD,
+                targetLevel = Design.LevelType.HARD,
                 coverImageUrl = "http://test.kroffle.com/image.jpg",
                 techniques = listOf("겉뜨기", "안뜨기")
             )

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -3,9 +3,6 @@ package com.kroffle.knitting.controller.router.design
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.domain.design.entity.Design
-import com.kroffle.knitting.domain.design.enum.DesignType
-import com.kroffle.knitting.domain.design.enum.LevelType
-import com.kroffle.knitting.domain.design.enum.PatternType
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
@@ -68,8 +65,8 @@ class DesignsRouterTest {
                         id = 1,
                         knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
                         name = "캔디리더 효정 니트",
-                        designType = DesignType.Sweater,
-                        patternType = PatternType.Text,
+                        designType = Design.DesignType.Sweater,
+                        patternType = Design.PatternType.Text,
                         gauge = Gauge(
                             stitches = 23.5,
                             rows = 25.0,
@@ -86,7 +83,7 @@ class DesignsRouterTest {
                         extra = null,
                         pattern = Pattern("# Step1. 코를 10개 잡습니다."),
                         description = "이건 니트를 만드는 서술형 도안입니다.",
-                        targetLevel = LevelType.HARD,
+                        targetLevel = Design.LevelType.HARD,
                         coverImageUrl = "http://test.kroffle.com/image.jpg",
                         techniques = listOf(Technique("안뜨기"), Technique("겉뜨기")),
                         createdAt = today,

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/knitter/MyselfRouterTest.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.controller.router.knitter
 import com.kroffle.knitting.controller.handler.knitter.MyselfHandler
 import com.kroffle.knitting.controller.handler.knitter.dto.MyProfile
 import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummary
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
@@ -109,24 +109,30 @@ class MyselfRouterTest {
     fun `나의 판매 요약 정보가 잘 반환되어야 함`() {
         val yesterday = OffsetDateTime.now().minusDays(1).toLocalDate()
         val productsToBeCounted = Flux.just(
-            MockFactory.create(MockProductData(id = 1, content = "이 상품은요", inputStatus = InputStatus.REGISTERED)),
+            MockFactory.create(
+                MockProductData(
+                    id = 1,
+                    content = "이 상품은요",
+                    inputStatus = Product.InputStatus.REGISTERED
+                )
+            ),
             MockFactory.create(
                 MockProductData(
                     id = 2,
                     content = "이 상품은요",
-                    inputStatus = InputStatus.REGISTERED,
+                    inputStatus = Product.InputStatus.REGISTERED,
                     specifiedSalesStartDate = yesterday,
                 )
             ),
         )
         val productsToBeSkipped = Flux.just(
-            MockFactory.create(MockProductData(id = 3, inputStatus = InputStatus.DRAFT)),
-            MockFactory.create(MockProductData(id = 4, content = "이 상품은요", inputStatus = InputStatus.DRAFT)),
+            MockFactory.create(MockProductData(id = 3, inputStatus = Product.InputStatus.DRAFT)),
+            MockFactory.create(MockProductData(id = 4, content = "이 상품은요", inputStatus = Product.InputStatus.DRAFT)),
             MockFactory.create(
                 MockProductData(
                     id = 5,
                     content = "이 상품은요",
-                    inputStatus = InputStatus.REGISTERED,
+                    inputStatus = Product.InputStatus.REGISTERED,
                     specifiedSalesEndDate = yesterday,
                 )
             ),

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -8,8 +8,6 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProduct
 import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.enum.InputStatus
-import com.kroffle.knitting.domain.product.enum.ProductItemType
 import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
@@ -85,13 +83,13 @@ class ProductRouterTest {
             specifiedSalesStartDate = null,
             specifiedSalesEndDate = tomorrow.toLocalDate(),
             content = null,
-            inputStatus = InputStatus.DRAFT,
+            inputStatus = Product.InputStatus.DRAFT,
             tags = listOf(
                 ProductTag("서술형도안"),
                 ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItem.Type.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -162,13 +160,13 @@ class ProductRouterTest {
             specifiedSalesStartDate = null,
             specifiedSalesEndDate = tomorrow.toLocalDate(),
             content = null,
-            inputStatus = InputStatus.DRAFT,
+            inputStatus = Product.InputStatus.DRAFT,
             tags = listOf(
                 ProductTag("서술형도안"),
                 ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItem.Type.DESIGN),
             ),
             createdAt = today,
             updatedAt = today,
@@ -183,7 +181,7 @@ class ProductRouterTest {
                 specifiedSalesStartDate = tomorrow.toLocalDate(),
                 specifiedSalesEndDate = null,
                 tags = listOf(ProductTag("서술형도안")),
-                items = listOf(ProductItem.create(2, ProductItemType.DESIGN))
+                items = listOf(ProductItem.create(2, ProductItem.Type.DESIGN))
             )
         given(repository.getProductByIdAndKnitterId(any(), any()))
             .willReturn(Mono.just(targetProduct))
@@ -266,13 +264,13 @@ class ProductRouterTest {
             specifiedSalesStartDate = null,
             specifiedSalesEndDate = tomorrow.toLocalDate(),
             content = null,
-            inputStatus = InputStatus.DRAFT,
+            inputStatus = Product.InputStatus.DRAFT,
             tags = listOf(
                 ProductTag("서술형도안"),
                 ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItem.Type.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,
@@ -333,13 +331,13 @@ class ProductRouterTest {
             specifiedSalesStartDate = null,
             specifiedSalesEndDate = null,
             content = "이번에는 초보탈출 패키지를 준비해봤어요.",
-            inputStatus = InputStatus.DRAFT,
+            inputStatus = Product.InputStatus.DRAFT,
             tags = listOf(
                 ProductTag("서술형도안"),
                 ProductTag("초보자용"),
             ),
             items = listOf(
-                ProductItem.create(1, ProductItemType.DESIGN),
+                ProductItem.create(1, ProductItem.Type.DESIGN),
             ),
             createdAt = yesterday,
             updatedAt = yesterday,

--- a/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.helper.dto
 
-import com.kroffle.knitting.domain.product.enum.InputStatus
+import com.kroffle.knitting.domain.product.entity.Product
 import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
@@ -19,7 +19,7 @@ data class MockProductData(
     val specifiedSalesEndDate: LocalDate? = null,
     val tags: List<ProductTag> = listOf(),
     val content: String? = null,
-    val inputStatus: InputStatus = InputStatus.DRAFT,
+    val inputStatus: Product.InputStatus = Product.InputStatus.DRAFT,
     val items: List<ProductItem> = listOf(),
     val createdAt: OffsetDateTime? = OffsetDateTime.now(),
     val updatedAt: OffsetDateTime? = OffsetDateTime.now(),


### PR DESCRIPTION
## PR 제안 사유
- enum을 사용하는 class는 한정되어있기 때문에 class 내부로 이동시킵니다.

## 주요 변경 기록

- enum 위치 변경
- 중복되는 네이밍 변경 (A 안에 있는 AStatus의 경우 Status로 변경)