### PR TITLE
refactor: 각종 리팩토링 모음전

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
@@ -3,6 +3,7 @@ package com.kroffle.knitting.controller.filter.cors
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -20,11 +21,13 @@ class CORSFilter(private val webProperties: WebApplicationProperties) : WebFilte
         if (CorsUtils.isCorsRequest(request)) {
             val response = exchange.response
             val headers = response.headers
-            headers.add("Access-Control-Allow-Origin", webProperties.origins.joinToString(","))
-            headers.add("Access-Control-Allow-Methods", "*")
-            headers.add("Access-Control-Max-Age", "3600")
-            headers.add("Access-Control-Allow-Headers", "Authorization")
-            headers.add("Access-Control-Allow-Headers", "Content-Type")
+
+            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, webProperties.origins.joinToString(","))
+            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "*")
+            headers.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "3600")
+            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization")
+            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+
             if (request.method == HttpMethod.OPTIONS) {
                 response.statusCode = HttpStatus.OK
                 return Mono.empty()

--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
@@ -1,7 +1,6 @@
 package com.kroffle.knitting.controller.filter.cors
 
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpMethod
@@ -15,10 +14,7 @@ import reactor.core.publisher.Mono
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
-class CORSFilter : WebFilter {
-    @Autowired
-    lateinit var webProperties: WebApplicationProperties
-
+class CORSFilter(private val webProperties: WebApplicationProperties) : WebFilter {
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
         val request = exchange.request
         if (CorsUtils.isCorsRequest(request)) {

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/AppConfig.kt
@@ -10,24 +10,16 @@ import com.kroffle.knitting.infra.properties.ClientProperties
 import com.kroffle.knitting.infra.properties.SelfProperties
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.auth.AuthService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class AppConfig {
-    @Autowired
-    lateinit var webProperties: WebApplicationProperties
-
-    @Autowired
-    lateinit var selfProperties: SelfProperties
-
-    @Autowired
-    lateinit var authProperties: AuthProperties
-
-    @Autowired
-    lateinit var clientProperties: ClientProperties
-
+class AppConfig(
+    private val webProperties: WebApplicationProperties,
+    private val selfProperties: SelfProperties,
+    private val authProperties: AuthProperties,
+    private val clientProperties: ClientProperties,
+) {
     @Bean
     fun tokenDecoder() = TokenDecoder(authProperties.jwtSecretKey)
 
@@ -35,7 +27,7 @@ class AppConfig {
     fun tokenPublisher() = TokenPublisher(authProperties.jwtSecretKey)
 
     @Bean
-    fun authService(repository: AuthService.KnitterRepository): AuthService {
+    fun googleOAuthHelper(): AuthService.OAuthHelper {
         val scheme = when (selfProperties.env) {
             "local" -> "http"
             else -> "https"
@@ -44,13 +36,9 @@ class AppConfig {
         val googleClientId = webProperties.googleClientId
         val googleClientSecret = webProperties.googleClientSecret
 
-        return AuthService(
-            GoogleOAuthHelperImpl(
-                ClientInfo(scheme, host),
-                GoogleOAuthConfig(googleClientId, googleClientSecret),
-            ),
-            tokenPublisher(),
-            repository,
+        return GoogleOAuthHelperImpl(
+            ClientInfo(scheme, host),
+            GoogleOAuthConfig(googleClientId, googleClientSecret),
         )
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/configuration/R2dbcConfiguration.kt
@@ -12,7 +12,6 @@ import io.r2dbc.postgresql.PostgresqlConnectionConfiguration
 import io.r2dbc.postgresql.PostgresqlConnectionFactory
 import io.r2dbc.postgresql.codec.EnumCodec
 import io.r2dbc.spi.ConnectionFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration
@@ -20,17 +19,14 @@ import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
 
 @Configuration
 @EnableR2dbcRepositories
-class R2dbcConfiguration : AbstractR2dbcConfiguration() {
-    @Autowired
-    lateinit var appProperties: DatabaseProperties
-
+class R2dbcConfiguration(private val databaseProperties: DatabaseProperties) : AbstractR2dbcConfiguration() {
     @Bean
     override fun connectionFactory(): ConnectionFactory = PostgresqlConnectionFactory(
         PostgresqlConnectionConfiguration.builder()
-            .host(appProperties.host)
-            .username(appProperties.username)
-            .password(appProperties.password)
-            .database(appProperties.database)
+            .host(databaseProperties.host)
+            .username(databaseProperties.username)
+            .password(databaseProperties.password)
+            .database(databaseProperties.database)
             .codecRegistrar(EnumCodec.builder().withEnum(DESIGN_TYPE, Design.DesignType::class.java).build())
             .codecRegistrar(EnumCodec.builder().withEnum(PATTERN_TYPE, Design.PatternType::class.java).build())
             .codecRegistrar(EnumCodec.builder().withEnum(INPUT_STATUS, Product.InputStatus::class.java).build())

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
@@ -12,16 +12,16 @@ import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.repository.DesignRepository
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList
 
-@Component
-class R2dbcDesignRepository(
-    private val designRepository: DBDesignRepository,
-    private val techniqueRepository: DBTechniqueRepository,
-    private val sizeRepository: DBSizeRepository,
+@Repository
+class DesignRepositoryImpl(
+    private val designRepository: R2DBCDesignRepository,
+    private val techniqueRepository: R2DBCTechniqueRepository,
+    private val sizeRepository: R2DBCSizeRepository,
 ) : DesignRepository {
     override fun createDesign(design: Design): Mono<Design> =
         designRepository

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCDesignRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
-interface DBDesignRepository : ReactiveCrudRepository<DesignEntity, Long> {
+interface R2DBCDesignRepository : ReactiveCrudRepository<DesignEntity, Long> {
     fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<DesignEntity>
     fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<DesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCSizeRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCSizeRepository.kt
@@ -1,11 +1,11 @@
 package com.kroffle.knitting.infra.persistence.design.repository
 
-import com.kroffle.knitting.infra.persistence.design.entity.TechniqueEntity
+import com.kroffle.knitting.infra.persistence.design.entity.SizeEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface DBTechniqueRepository : ReactiveCrudRepository<TechniqueEntity, Long> {
+interface R2DBCSizeRepository : ReactiveCrudRepository<SizeEntity, Long> {
     fun deleteByDesignId(designId: Long): Mono<Long>
-    fun findAllByDesignIdIn(designIds: List<Long>): Flux<TechniqueEntity>
+    fun findAllByDesignIdIn(designIds: List<Long>): Flux<SizeEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCTechniqueRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCTechniqueRepository.kt
@@ -1,11 +1,11 @@
 package com.kroffle.knitting.infra.persistence.design.repository
 
-import com.kroffle.knitting.infra.persistence.design.entity.SizeEntity
+import com.kroffle.knitting.infra.persistence.design.entity.TechniqueEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface DBSizeRepository : ReactiveCrudRepository<SizeEntity, Long> {
+interface R2DBCTechniqueRepository : ReactiveCrudRepository<TechniqueEntity, Long> {
     fun deleteByDesignId(designId: Long): Mono<Long>
-    fun findAllByDesignIdIn(designIds: List<Long>): Flux<SizeEntity>
+    fun findAllByDesignIdIn(designIds: List<Long>): Flux<TechniqueEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/KnitterRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/KnitterRepositoryImpl.kt
@@ -5,11 +5,11 @@ import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.infra.persistence.knitter.entity.KnitterEntity
 import com.kroffle.knitting.infra.persistence.knitter.entity.toKnitterEntity
 import com.kroffle.knitting.usecase.repository.KnitterRepository
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import reactor.core.publisher.Mono
 
-@Component
-class R2dbcKnitterRepository(private val repository: DBKnitterRepository) : KnitterRepository {
+@Repository
+class KnitterRepositoryImpl(private val repository: R2DBCKnitterRepository) : KnitterRepository {
     override fun create(user: Knitter): Mono<Knitter> =
         repository
             .save(user.toKnitterEntity())

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2DBCKnitterRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/knitter/repository/R2DBCKnitterRepository.kt
@@ -4,6 +4,6 @@ import com.kroffle.knitting.infra.persistence.knitter.entity.KnitterEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Mono
 
-interface DBKnitterRepository : ReactiveCrudRepository<KnitterEntity, Long> {
+interface R2DBCKnitterRepository : ReactiveCrudRepository<KnitterEntity, Long> {
     fun findFirstByEmail(email: String): Mono<KnitterEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/ProductRepositoryImpl.kt
@@ -13,16 +13,16 @@ import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.repository.ProductRepository
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.stream.Collectors.toList
 
-@Component
-class R2dbcProductRepository(
-    private val productRepository: DBProductRepository,
-    private val productTagRepository: DBProductTagRepository,
-    private val productItemRepository: DBProductItemRepository,
+@Repository
+class ProductRepositoryImpl(
+    private val productRepository: R2DBCProductRepository,
+    private val productTagRepository: R2DBCProductTagRepository,
+    private val productItemRepository: R2DBCProductItemRepository,
 ) : ProductRepository {
     private fun findById(id: Long): Mono<Product> {
         val tags = productTagRepository

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductItemRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductItemRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface DBProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long> {
+interface R2DBCProductItemRepository : ReactiveCrudRepository<ProductItemEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductItemEntity>
     fun findAllByProductIdIn(productId: List<Long>): Flux<ProductItemEntity>
     fun deleteByProductId(productId: Long): Mono<Long>

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
-interface DBProductRepository : ReactiveCrudRepository<ProductEntity, Long> {
+interface R2DBCProductRepository : ReactiveCrudRepository<ProductEntity, Long> {
     fun findAllByKnitterIdAndInputStatus(knitterId: Long, inputStatus: Product.InputStatus): Flux<ProductEntity>
     fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<ProductEntity>
     fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<ProductEntity>

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductTagRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/repository/R2DBCProductTagRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface DBProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long> {
+interface R2DBCProductTagRepository : ReactiveCrudRepository<ProductTagEntity, Long> {
     fun findAllByProductId(productId: Long): Flux<ProductTagEntity>
     fun findAllByProductIdIn(productId: List<Long>): Flux<ProductTagEntity>
     fun deleteByProductId(productId: Long): Mono<Long>

--- a/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/auth/AuthService.kt
@@ -2,10 +2,12 @@ package com.kroffle.knitting.usecase.auth
 
 import com.kroffle.knitting.domain.knitter.entity.Knitter
 import com.kroffle.knitting.usecase.auth.dto.OAuthProfile
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.switchIfEmpty
 import java.net.URI
 
+@Service
 class AuthService(
     private val oAuthHelper: OAuthHelper,
     private val tokenPublisher: TokenPublisher,

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -5,11 +5,11 @@ import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-@Component
+@Service
 class DesignService(private val repository: DesignRepository) {
     fun create(data: CreateDesignData): Mono<Design> =
         repository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/knitter/KnitterService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/knitter/KnitterService.kt
@@ -1,10 +1,10 @@
 package com.kroffle.knitting.usecase.knitter
 
 import com.kroffle.knitting.domain.knitter.entity.Knitter
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 
-@Component
+@Service
 class KnitterService(private val knitterRepository: KnitterRepository) {
     fun getKnitter(knitterId: Long): Mono<Knitter> =
         knitterRepository.getById(knitterId)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/ProductService.kt
@@ -8,11 +8,11 @@ import com.kroffle.knitting.usecase.product.dto.EditProductPackageData
 import com.kroffle.knitting.usecase.product.dto.GetMyProductData
 import com.kroffle.knitting.usecase.product.dto.GetMyProductsData
 import com.kroffle.knitting.usecase.product.dto.RegisterProductData
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-@Component
+@Service
 class ProductService(private val repository: ProductRepository) {
     fun edit(data: EditProductPackageData): Mono<Product> =
         if (data.id == null) {

--- a/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/summary/ProductSummaryService.kt
@@ -1,11 +1,11 @@
 package com.kroffle.knitting.usecase.summary
 
 import com.kroffle.knitting.domain.product.entity.Product
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-@Component
+@Service
 class ProductSummaryService(private val repository: ProductRepository) {
     fun countProductOnList(knitterId: Long): Mono<Long> =
         repository


### PR DESCRIPTION
## PR 제안 사유
- 작업하다보니 예전에 왜 이렇게 해뒀지 싶었던 것들 보이는 것 위주로 청소해주었습니다.
   

## 주요 변경 기록
- Service, Repository 어노테이션 사용하도록 변경
- AuthService 직접 bean으로 생성하지 않고, 필요한 bean을 등록해서 주입받아 사용하도록 수정
- 필드 주입 받고 있던 (Autowired) 부분 constructor 주입으로 변경
- string으로 관리하던 http header constant 변수 이용하도록 변경
- repository 이름들 변경