### PR TITLE
feat: 도안 임시저장 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -14,6 +14,7 @@ import reactor.core.publisher.Mono
 @Component
 class DraftDesignHandler(private val service: DraftDesignService) {
     fun saveDraft(req: ServerRequest): Mono<ServerResponse> {
+        // TODO: Add unit test
         val body: Mono<SaveDraftDesign.Request> = req
             .bodyToMono(SaveDraftDesign.Request::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -1,0 +1,36 @@
+package com.kroffle.knitting.controller.handler.draftdesign
+
+import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
+import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
+import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
+import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
+import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
+import com.kroffle.knitting.usecase.draftdesign.dto.SaveDraftDesignData
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+@Component
+class DraftDesignHandler(private val service: DraftDesignService) {
+    fun saveDraft(req: ServerRequest): Mono<ServerResponse> {
+        val body: Mono<SaveDraftDesign.Request> = req
+            .bodyToMono(SaveDraftDesign.Request::class.java)
+            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val knitterId = AuthHelper.getKnitterId(req)
+        return body
+            .flatMap {
+                service
+                    .saveDraft(
+                        SaveDraftDesignData(
+                            id = it.id,
+                            knitterId = knitterId,
+                            designId = it.designId,
+                            value = it.value,
+                        )
+                    )
+            }
+            .map { SaveDraftDesign.Response(it.id!!) }
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/SaveDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/SaveDraftDesign.kt
@@ -1,0 +1,15 @@
+package com.kroffle.knitting.controller.handler.draftdesign.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+
+object SaveDraftDesign {
+    data class Request(
+        val id: Long?,
+        val designId: Long?,
+        val value: String,
+    )
+
+    data class Response(
+        val id: Long,
+    ) : ObjectPayload
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.controller.router.design
 
 import com.kroffle.knitting.controller.handler.design.DesignHandler
+import com.kroffle.knitting.controller.handler.draftdesign.DraftDesignHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RequestPredicates.path
@@ -8,19 +9,25 @@ import org.springframework.web.reactive.function.server.RouterFunctions.nest
 import org.springframework.web.reactive.function.server.router
 
 @Configuration
-class DesignRouter(private val handler: DesignHandler) {
+class DesignRouter(
+    private val designHandler: DesignHandler,
+    private val draftDesignHandler: DraftDesignHandler,
+) {
     @Bean
     fun designRouterFunction() = nest(
         path(ROOT_PATH),
         router {
             listOf(
-                POST(handler::createDesign),
+                POST(CREATE_DESIGN_PATH, designHandler::createDesign),
+                POST(SAVE_DRAFT_PATH, draftDesignHandler::saveDraft)
             )
         }
     )
 
     companion object {
         private const val ROOT_PATH = "/design"
+        private const val CREATE_DESIGN_PATH = ""
+        private const val SAVE_DRAFT_PATH = "/draft"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/draftdesign/entity/DraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/draftdesign/entity/DraftDesign.kt
@@ -1,0 +1,30 @@
+package com.kroffle.knitting.domain.draftdesign.entity
+
+import java.time.OffsetDateTime
+
+data class DraftDesign(
+    val id: Long? = null,
+    val knitterId: Long,
+    val value: String,
+    val designId: Long?,
+    val createdAt: OffsetDateTime?,
+    val updatedAt: OffsetDateTime?,
+) {
+    fun merge(value: String): DraftDesign =
+        this.copy(
+            value = value,
+            updatedAt = OffsetDateTime.now(),
+        )
+
+    companion object {
+        fun new(knitterId: Long, designId: Long?, value: String): DraftDesign =
+            DraftDesign(
+                id = null,
+                knitterId = knitterId,
+                designId = designId,
+                value = value,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCDesignRepository.kt
@@ -4,8 +4,10 @@ import com.kroffle.knitting.infra.persistence.design.entity.DesignEntity
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface R2DBCDesignRepository : ReactiveCrudRepository<DesignEntity, Long> {
+    fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DesignEntity>
     fun findAllByKnitterId(knitterId: Long, pageable: Pageable): Flux<DesignEntity>
     fun findAllByKnitterIdAndIdBefore(knitterId: Long, id: Long, pageable: Pageable): Flux<DesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCSizeRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCSizeRepository.kt
@@ -8,4 +8,5 @@ import reactor.core.publisher.Mono
 interface R2DBCSizeRepository : ReactiveCrudRepository<SizeEntity, Long> {
     fun deleteByDesignId(designId: Long): Mono<Long>
     fun findAllByDesignIdIn(designIds: List<Long>): Flux<SizeEntity>
+    fun findByDesignId(designId: Long): Mono<SizeEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCTechniqueRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/R2DBCTechniqueRepository.kt
@@ -8,4 +8,5 @@ import reactor.core.publisher.Mono
 interface R2DBCTechniqueRepository : ReactiveCrudRepository<TechniqueEntity, Long> {
     fun deleteByDesignId(designId: Long): Mono<Long>
     fun findAllByDesignIdIn(designIds: List<Long>): Flux<TechniqueEntity>
+    fun findAllByDesignId(designId: Long): Flux<TechniqueEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/entity/DraftDesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/entity/DraftDesignEntity.kt
@@ -1,0 +1,36 @@
+package com.kroffle.knitting.infra.persistence.draftdesign.entity
+
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.OffsetDateTime
+
+@Table("draft_design")
+class DraftDesignEntity(
+    @Id private var id: Long?,
+    private val knitterId: Long,
+    private val designId: Long?,
+    private val value: String,
+    private val createdAt: OffsetDateTime = OffsetDateTime.now(),
+    private val updatedAt: OffsetDateTime = OffsetDateTime.now(),
+) {
+    fun toDraftDesign(): DraftDesign =
+        DraftDesign(
+            id = this.id,
+            knitterId = this.knitterId,
+            designId = this.designId,
+            value = this.value,
+            createdAt = this.createdAt,
+            updatedAt = this.updatedAt,
+        )
+}
+
+fun DraftDesign.toDraftDesignEntity(): DraftDesignEntity =
+    DraftDesignEntity(
+        id = this.id,
+        knitterId = this.knitterId,
+        designId = this.designId,
+        value = this.value,
+        createdAt = this.createdAt ?: OffsetDateTime.now(),
+        updatedAt = this.updatedAt ?: OffsetDateTime.now(),
+    )

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.kroffle.knitting.infra.persistence.draftdesign.repository
+
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
+import com.kroffle.knitting.infra.persistence.draftdesign.entity.toDraftDesignEntity
+import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
+import com.kroffle.knitting.usecase.repository.DraftDesignRepository
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Mono
+
+@Repository
+class DraftDesignRepositoryImpl(
+    private val draftDesignRepository: R2DBCDraftDesignRepository,
+) : DraftDesignRepository {
+    override fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign> =
+        draftDesignRepository
+            .findByIdAndKnitterId(id, knitterId)
+            .switchIfEmpty(Mono.error(NotFoundEntity(DraftDesign::class.java)))
+            .map { it.toDraftDesign() }
+
+    override fun save(draftDesign: DraftDesign): Mono<DraftDesign> =
+        draftDesignRepository
+            .save(draftDesign.toDraftDesignEntity())
+            .map { it.toDraftDesign() }
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
@@ -1,0 +1,9 @@
+package com.kroffle.knitting.infra.persistence.draftdesign.repository
+
+import com.kroffle.knitting.infra.persistence.draftdesign.entity.DraftDesignEntity
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Mono
+
+interface R2DBCDraftDesignRepository : ReactiveCrudRepository<DraftDesignEntity, Long> {
+    fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesignEntity>
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -36,11 +36,11 @@ class DraftDesignService(
     }
 
     fun saveDraft(data: SaveDraftDesignData): Mono<DraftDesign> {
-        return if (data.designId != null) {
+        return if (data.designId == null) {
+            saveDraftDesign(data)
+        } else {
             verifyDesignId(data.designId, data.knitterId)
                 .flatMap { saveDraftDesign(data) }
-        } else {
-            saveDraftDesign(data)
         }
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -1,0 +1,55 @@
+package com.kroffle.knitting.usecase.draftdesign
+
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
+import com.kroffle.knitting.usecase.draftdesign.dto.SaveDraftDesignData
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+
+@Service
+class DraftDesignService(
+    private val draftDesignRepository: DraftDesignRepository,
+    private val designRepository: DesignRepository,
+) {
+    private fun verifyDesignId(designId: Long, knitterId: Long): Mono<Design> {
+        return designRepository
+            .findByIdAndKnitterId(designId, knitterId)
+    }
+
+    private fun saveDraftDesign(data: SaveDraftDesignData): Mono<DraftDesign> {
+        return if (data.id == null) {
+            draftDesignRepository.save(
+                DraftDesign.new(
+                    knitterId = data.knitterId,
+                    designId = data.designId,
+                    value = data.value,
+                )
+            )
+        } else {
+            draftDesignRepository
+                .findByIdAndKnitterId(data.id, data.knitterId)
+                .map { it.merge(data.value) }
+                .flatMap {
+                    draftDesignRepository.save(it)
+                }
+        }
+    }
+
+    fun saveDraft(data: SaveDraftDesignData): Mono<DraftDesign> {
+        return if (data.designId != null) {
+            verifyDesignId(data.designId, data.knitterId)
+                .flatMap { saveDraftDesign(data) }
+        } else {
+            saveDraftDesign(data)
+        }
+    }
+
+    interface DraftDesignRepository {
+        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
+        fun save(draftDesign: DraftDesign): Mono<DraftDesign>
+    }
+
+    interface DesignRepository {
+        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<Design>
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/dto/SaveDraftDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/dto/SaveDraftDesignData.kt
@@ -1,0 +1,8 @@
+package com.kroffle.knitting.usecase.draftdesign.dto
+
+data class SaveDraftDesignData(
+    val id: Long?,
+    val knitterId: Long,
+    val designId: Long?,
+    val value: String,
+)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/DesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/DesignRepository.kt
@@ -1,5 +1,8 @@
 package com.kroffle.knitting.usecase.repository
 
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
 
-interface DesignRepository : DesignService.DesignRepository
+interface DesignRepository :
+    DesignService.DesignRepository,
+    DraftDesignService.DesignRepository

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/DraftDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/DraftDesignRepository.kt
@@ -1,0 +1,5 @@
+package com.kroffle.knitting.usecase.repository
+
+import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
+
+interface DraftDesignRepository : DraftDesignService.DraftDesignRepository

--- a/src/main/resources/db/migration/V10__add_draft_design.sql
+++ b/src/main/resources/db/migration/V10__add_draft_design.sql
@@ -1,0 +1,9 @@
+CREATE TABLE draft_design (
+    id BIGSERIAL NOT NULL,
+    knitter_id bigint NOT NULL REFERENCES knitter(id),
+    design_id bigint REFERENCES design(id),
+    value VARCHAR NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_At TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
## PR 제안 사유
- 도안을 임시저장 할 수 있도록 API를 추가합니다.
- 도안 생성시 보내는 API request를 string으로 변환하여 value로 요청하면 됩니다.

Resolves https://app.clickup.com/t/1r6afh0

## 주요 변경 기록
- draft design 도메인 추가
- draft design 생성할 수 있도록 API 구현


## API 문서

4가지의 케이스가 있을 수 있고 각 케이스들은 example로 추가해두었습니다.
- 도안 생성 중에 생긴 임시저장 생성
- 도안 생성 중에 생긴 임시저장 수정
- 도안 수정 중에 생긴 임시저장 생성
- 도안 수정 중에 생긴 임시저장 수정

https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-06a06cfa-1983-4d04-a99f-35361c57fa2e
