### PR TITLE
feat: 도안 저장시 임시저장 내역 제거

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -69,6 +69,7 @@ class DesignHandler(private val service: DesignService) {
                         targetLevel = it.targetLevel,
                         coverImageUrl = it.coverImageUrl,
                         techniques = it.techniques.map { technique -> Technique(technique) },
+                        draftId = it.draftId,
                     )
                 )
             }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
@@ -25,6 +25,8 @@ object NewDesign {
         @JsonProperty("cover_image_url")
         val coverImageUrl: String,
         val techniques: List<String>,
+        @JsonProperty("draft_id")
+        val draftId: Long?,
     ) {
         data class NewDesignSize(
             @JsonProperty("size_unit")

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -21,4 +21,7 @@ class DraftDesignRepositoryImpl(
         draftDesignRepository
             .save(draftDesign.toDraftDesignEntity())
             .map { it.toDraftDesign() }
+
+    override fun delete(draftDesign: DraftDesign): Mono<Long> =
+        draftDesignRepository.delete(draftDesign.toDraftDesignEntity()).map { draftDesign.id }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.usecase.design
 
 import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
@@ -10,30 +11,54 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Service
-class DesignService(private val repository: DesignRepository) {
-    fun create(data: CreateDesignData): Mono<Design> =
-        repository
+class DesignService(
+    private val designRepository: DesignRepository,
+    private val draftDesignRepository: DraftDesignRepository,
+) {
+    private fun createDesign(data: CreateDesignData): Mono<Design> =
+        designRepository
             .createDesign(
                 Design.new(
-                    data.knitterId,
-                    data.name,
-                    data.designType,
-                    data.patternType,
-                    data.gauge,
-                    data.size,
-                    data.needle,
-                    data.yarn,
-                    data.extra,
-                    data.pattern,
-                    data.description,
-                    data.targetLevel,
-                    data.coverImageUrl,
-                    data.techniques,
+                    knitterId = data.knitterId,
+                    name = data.name,
+                    designType = data.designType,
+                    patternType = data.patternType,
+                    gauge = data.gauge,
+                    size = data.size,
+                    needle = data.needle,
+                    yarn = data.yarn,
+                    extra = data.extra,
+                    pattern = data.pattern,
+                    description = data.description,
+                    targetLevel = data.targetLevel,
+                    coverImageUrl = data.coverImageUrl,
+                    techniques = data.techniques,
                 )
             )
 
+    fun create(data: CreateDesignData): Mono<Design> {
+        return if (data.draftId == null) {
+            createDesign(data)
+        } else {
+            // TODO test case 추가
+            createDesign(data)
+                .flatMap { design ->
+                    draftDesignRepository
+                        .findByIdAndKnitterId(
+                            id = data.draftId,
+                            knitterId = data.knitterId,
+                        )
+                        .flatMap {
+                            draftDesignRepository
+                                .delete(it)
+                                .map { design }
+                        }
+                }
+        }
+    }
+
     fun getMyDesign(filter: MyDesignFilter): Flux<Design> =
-        repository
+        designRepository
             .getDesignsByKnitterId(
                 filter.knitterId,
                 filter.paging,
@@ -43,5 +68,10 @@ class DesignService(private val repository: DesignRepository) {
     interface DesignRepository {
         fun createDesign(design: Design): Mono<Design>
         fun getDesignsByKnitterId(knitterId: Long, paging: Paging, sort: Sort): Flux<Design>
+    }
+
+    interface DraftDesignRepository {
+        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
+        fun delete(draftDesign: DraftDesign): Mono<Long>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
@@ -21,4 +21,5 @@ data class CreateDesignData(
     val targetLevel: Design.LevelType,
     val coverImageUrl: String,
     val techniques: List<Technique>,
+    val draftId: Long?,
 )

--- a/src/main/kotlin/com/kroffle/knitting/usecase/repository/DraftDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/repository/DraftDesignRepository.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.usecase.repository
 
+import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
 
-interface DraftDesignRepository : DraftDesignService.DraftDesignRepository
+interface DraftDesignRepository : DraftDesignService.DraftDesignRepository, DesignService.DraftDesignRepository

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -59,7 +59,7 @@ class DesignRouterTest {
 
     @BeforeEach
     fun setUp() {
-        val designHandler = DesignHandler(DesignService(designRepository))
+        val designHandler = DesignHandler(DesignService(designRepository, draftDesignRepository))
         val draftDesignHandler = DraftDesignHandler(DraftDesignService(draftDesignRepository, designRepository))
         val designRouter = DesignRouter(designHandler, draftDesignHandler)
         webClient = WebTestClientHelper
@@ -118,7 +118,8 @@ class DesignRouterTest {
                 description = "이건 니트를 만드는 서술형 도안입니다.",
                 targetLevel = Design.LevelType.HARD,
                 coverImageUrl = "http://test.kroffle.com/image.jpg",
-                techniques = listOf("겉뜨기", "안뜨기")
+                techniques = listOf("겉뜨기", "안뜨기"),
+                draftId = null,
             )
         )
         val response: TestResponse<NewDesign.Response> =


### PR DESCRIPTION
## PR 제안 사유
- 도안을 저장할 때 임시저장 된 내역을 제거할 수 있도록 합니다.
- 클라이언트에서는 임시저장 내역을 불러와서 화면에 그려준 후 저장할 때에는 임시저장과는 별개로 기존에 저장시 보내던 데이터를 그대로 보내주면 되고, draft_id에 임시저장 id를 지정하여 요청하면 됩니다.
- 임시저장 id는 현재 클라이언트에서 알 수 없는 상태로 일단은 null로 요청하도록 작업하면 될 것 같습니다.

Resolves #1tm149f

## 주요 변경 기록
- 도안 생성 API request에 draft_id 추가
- draft_id가 있는 경우, 도안 저장 후 임시 저장 내역 제거
- draft_id가 없는 경우, 도안 저장만 진행

FYI: 테스트 코드는 망엉창진라서 조만간 kotest로 옮겨가며 처음부터 다시 작성할 예정입니다.