### PR TITLE
feat: client host 설정 변경

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ db.username=postgres
 db.database=knitting
 db.password=${KNITTING_POSTGRES_PASSWORD}
 
-web.origins=http://localhost:1909
+web.origins=http://localhost:1909,https://knitting-314112.web.app
 web.google.client_id=1036534335923-fcacoteap126dnkl0ttuouaguercstbi.apps.googleusercontent.com
 web.google.client_secret=${KNITTING_GOOGLE_CLIENT_SECRET}
 web.jwt_secret_key=${KNITTING_JWT_SECRET_KEY}
@@ -13,7 +13,7 @@ web.jwt_secret_key=${KNITTING_JWT_SECRET_KEY}
 self.host=wordway.cafe24.com
 self.env=local
 
-client.host=localhost:1909
+client.host=knitting-314112.web.app
 
 server.error.whitelabel.enabled=false
 server.error.include-message=always


### PR DESCRIPTION
## PR 제안 사유
- https://knitting-314112.web.app/login 에서 로그인하면 localhost로 리다이렉트 되는데 다시 배포된 클라이언트로 돌아갈 수 있도록 설정을 변경합니다.
- 로컬에서 prod랑 연결해서 테스트할 때에는 아무래도 localstrage에 token 임의로 넣어서 로그인 시키는게 좋을 것 같네요 🤔 

Resolves #1vrkdbc

## 주요 변경 기록
- client 설정 정보 변경
