### PR TITLE
feat: https 인증서 발급을 위해 필요한 인증 API 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -8,6 +8,7 @@ import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
+import com.kroffle.knitting.controller.router.auth.CertRouter.Companion.PUBLIC_PATHS as CertRouterPublicPaths
 import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
@@ -55,6 +56,7 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
         private const val HEADER_PREFIX = "Bearer "
         private val PUBLIC_PATHS = (
             LogInRouterPublicPaths +
+                CertRouterPublicPaths +
                 MyselfRouterPublicPaths +
                 DesignRouterPublicPaths +
                 DesignsRouterPublicPaths +

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/CertHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/CertHandler.kt
@@ -1,0 +1,15 @@
+package com.kroffle.knitting.controller.handler.auth
+
+import com.kroffle.knitting.usecase.auth.AuthService
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+@Component
+class CertHandler(private val authService: AuthService) {
+    fun applyHttps(req: ServerRequest): Mono<ServerResponse> = ServerResponse.ok()
+        .contentType(MediaType.TEXT_PLAIN)
+        .bodyValue("o7DtLtR3ccPKK71iDectTrZC6tftXInhTFDAuDNgYI0.ofrzhGihE4RkXTflExk0lLzBzcd0gZ3EvUq0VkFU1Vk")
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/CertRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/CertRouter.kt
@@ -1,0 +1,29 @@
+package com.kroffle.knitting.controller.router.auth
+
+import com.kroffle.knitting.controller.handler.auth.CertHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RequestPredicates
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.router
+
+@Configuration
+class CertRouter(private val handler: CertHandler) {
+    @Bean
+    fun certRouterFunction() = RouterFunctions.nest(
+        RequestPredicates.path(ROOT_PATH),
+        router {
+            listOf(
+                GET(APPLY_HTTPS_PATH, handler::applyHttps),
+            )
+        }
+    )
+
+    companion object {
+        private const val ROOT_PATH = "/"
+        private const val APPLY_HTTPS_PATH = ".well-known/acme-challenge/o7DtLtR3ccPKK71iDectTrZC6tftXInhTFDAuDNgYI0"
+        val PUBLIC_PATHS = listOf(
+            "$ROOT_PATH$APPLY_HTTPS_PATH",
+        )
+    }
+}


### PR DESCRIPTION
## PR 제안 사유
- ssl 인증서를 붙이기 위한 도메인 검증을 위해 필요한 API를 추가합니다.
- 설정 파일로 빼는건 후속으로 진행할게요~

Resolves #1vrmtm1

