### PR TITLE
fix: CORS origin 설정 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/cors/CORSFilter.kt
@@ -21,8 +21,7 @@ class CORSFilter(private val webProperties: WebApplicationProperties) : WebFilte
         if (CorsUtils.isCorsRequest(request)) {
             val response = exchange.response
             val headers = response.headers
-
-            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, webProperties.origins.joinToString(","))
+            headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "*")
             headers.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "3600")
             headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization")


### PR DESCRIPTION
## PR 제안 사유
- ACCESS_CONTROL_ALLOW_ORIGIN 에 origin을 여러개를 넣는 경우, 아래와 같은 에러가 발생합니다.
```
The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost:1909,https://knitting-314112.web.app', but only one is allowed.
```
- 해결하기 위해서는 요청이 들어온 클라이언트 origin에 따라 동적으로 헤더정보를 내려주어야 합니다.
- 우선은 배포를 끝내기 위해 모든 origin 을 허용하도록 수정합니다.