### PR TITLE
feat: 도안 작성시 가격 입력 받을 수 있도록 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -12,6 +12,7 @@ import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.usecase.design.DesignService
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
@@ -64,6 +65,7 @@ class DesignHandler(private val service: DesignService) {
                         needle = it.needle,
                         yarn = it.yarn,
                         extra = it.extra,
+                        price = Money(it.price),
                         pattern = Pattern(it.pattern),
                         description = it.description,
                         targetLevel = it.targetLevel,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
@@ -18,6 +18,7 @@ object NewDesign {
         val needle: String,
         val yarn: String,
         val extra: String?,
+        val price: Int,
         val pattern: String,
         val description: String,
         @JsonProperty("target_level")

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -11,9 +11,9 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProduct
 import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.product.ProductService

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -4,6 +4,7 @@ import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 import java.time.OffsetDateTime
 
 class Design(
@@ -17,6 +18,7 @@ class Design(
     val needle: String,
     val yarn: String,
     val extra: String?,
+    val price: Money,
     val pattern: Pattern,
     val description: String,
     val targetLevel: LevelType,
@@ -52,6 +54,7 @@ class Design(
             needle: String,
             yarn: String,
             extra: String?,
+            price: Money,
             pattern: Pattern,
             description: String,
             targetLevel: LevelType,
@@ -68,6 +71,7 @@ class Design(
             needle = needle,
             yarn = yarn,
             extra = extra,
+            price = price,
             pattern = pattern,
             description = description,
             targetLevel = targetLevel,

--- a/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/product/entity/Product.kt
@@ -5,9 +5,9 @@ import com.kroffle.knitting.domain.product.exception.InvalidFullPrice
 import com.kroffle.knitting.domain.product.exception.InvalidInputStatus
 import com.kroffle.knitting.domain.product.exception.InvalidPeriod
 import com.kroffle.knitting.domain.product.exception.UnableToRegister
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import java.time.LocalDate
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/value/Money.kt
@@ -1,4 +1,4 @@
-package com.kroffle.knitting.domain.product.value
+package com.kroffle.knitting.domain.value
 
 class Money(val value: Int) {
     operator fun compareTo(money: Money): Int =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -5,6 +5,7 @@ import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.OffsetDateTime
@@ -21,6 +22,7 @@ class DesignEntity(
     private val needle: String,
     private val yarn: String,
     private val extra: String?,
+    private val price: Int,
     private val pattern: String,
     private val description: String,
     private val targetLevel: String,
@@ -41,6 +43,7 @@ class DesignEntity(
             needle = this.needle,
             yarn = this.yarn,
             extra = this.extra,
+            price = Money(this.price),
             pattern = Pattern(this.pattern),
             description = this.description,
             targetLevel = Design.LevelType.valueOf(this.targetLevel),
@@ -62,6 +65,7 @@ fun Design.toDesignEntity() =
         needle = this.needle,
         yarn = this.yarn,
         extra = this.extra,
+        price = this.price.value,
         pattern = this.pattern.value,
         description = this.description,
         targetLevel = this.targetLevel.name,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/product/entity/ProductEntity.kt
@@ -1,9 +1,9 @@
 package com.kroffle.knitting.infra.persistence.product.entity
 
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -28,6 +28,7 @@ class DesignService(
                     needle = data.needle,
                     yarn = data.yarn,
                     extra = data.extra,
+                    price = data.price,
                     pattern = data.pattern,
                     description = data.description,
                     targetLevel = data.targetLevel,

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/CreateDesignData.kt
@@ -5,6 +5,7 @@ import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 
 data class CreateDesignData(
     val knitterId: Long,
@@ -16,6 +17,7 @@ data class CreateDesignData(
     val needle: String,
     val yarn: String,
     val extra: String?,
+    val price: Money,
     val pattern: Pattern,
     val description: String,
     val targetLevel: Design.LevelType,

--- a/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/EditProductPackageData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/product/dto/EditProductPackageData.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.usecase.product.dto
 
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import java.time.LocalDate
 
 data class EditProductPackageData(

--- a/src/main/resources/db/migration/V11__add_price_to_design.sql
+++ b/src/main/resources/db/migration/V11__add_price_to_design.sql
@@ -1,0 +1,5 @@
+ALTER TABLE design ADD COLUMN price NUMERIC;
+
+UPDATE design SET price = 0;
+
+ALTER TABLE design ALTER COLUMN price SET NOT NULL;

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignRouterTest.kt
@@ -10,6 +10,7 @@ import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
 import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
@@ -88,6 +89,7 @@ class DesignRouterTest {
             needle = "5.0mm",
             yarn = "캐시미어 400g",
             extra = null,
+            price = Money(1000),
             pattern = Pattern("# Step1. 코를 10개 잡습니다."),
             description = "이건 니트를 만드는 서술형 도안입니다.",
             targetLevel = Design.LevelType.HARD,
@@ -114,6 +116,7 @@ class DesignRouterTest {
                 needle = "5.0mm",
                 yarn = "캐시미어 400g",
                 extra = null,
+                price = 1000,
                 pattern = "# Step1. 코를 10개 잡습니다.",
                 description = "이건 니트를 만드는 서술형 도안입니다.",
                 targetLevel = Design.LevelType.HARD,
@@ -148,6 +151,7 @@ class DesignRouterTest {
                         design.needle == createdDesign.needle &&
                         design.yarn == createdDesign.yarn &&
                         design.extra == createdDesign.extra &&
+                        design.price.like(createdDesign.price) &&
                         design.pattern.like(createdDesign.pattern) &&
                         design.description == createdDesign.description &&
                         design.targetLevel == createdDesign.targetLevel &&

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -8,6 +8,7 @@ import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
 import com.kroffle.knitting.domain.design.value.Size
 import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper
 import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
@@ -85,6 +86,7 @@ class DesignsRouterTest {
                         needle = "5.0mm",
                         yarn = "패션아란 400g 1볼",
                         extra = null,
+                        price = Money(1000),
                         pattern = Pattern("# Step1. 코를 10개 잡습니다."),
                         description = "이건 니트를 만드는 서술형 도안입니다.",
                         targetLevel = Design.LevelType.HARD,

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/product/ProductRouterTest.kt
@@ -8,9 +8,9 @@ import com.kroffle.knitting.controller.handler.product.dto.GetMyProduct
 import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
 import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.TestResponse
 import com.kroffle.knitting.helper.WebTestClientHelper

--- a/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/dto/MockProductData.kt
@@ -1,9 +1,9 @@
 package com.kroffle.knitting.helper.dto
 
 import com.kroffle.knitting.domain.product.entity.Product
-import com.kroffle.knitting.domain.product.value.Money
 import com.kroffle.knitting.domain.product.value.ProductItem
 import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.WebTestClientHelper
 import java.time.LocalDate
 import java.time.OffsetDateTime

--- a/src/test/kotlin/com/kroffle/knitting/helper/extension/Money.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/extension/Money.kt
@@ -1,6 +1,6 @@
 package com.kroffle.knitting.helper.extension
 
-import com.kroffle.knitting.domain.product.value.Money
+import com.kroffle.knitting.domain.value.Money
 
 fun Money.like(other: Money): Boolean {
     if (this === other) return true


### PR DESCRIPTION
## PR 제안 사유
- 도안별로 가격을 지정할 수 있도록 가격을 입력받을 수 있도록 합니다.
- [클라이언트 작업](https://app.clickup.com/t/1vyej1g)을 필요로 합니다. 

Resolves #1vru2e2

## 주요 변경 기록
- Money class 상위로 이동
- Design 도메인에 price 정의
- Design 엔티티, table에 price 정의
- Design 생성 API request에 price 추가
