### PR TITLE
feat: 내가 작성중인 도안 리스트 조회 API

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesign.kt
@@ -1,0 +1,14 @@
+package com.kroffle.knitting.controller.handler.draftdesign.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
+import java.time.OffsetDateTime
+
+object MyDraftDesign {
+    data class Response(
+        val id: Long,
+        val name: String?,
+        val updatedAt: OffsetDateTime,
+    ) : ListItemPayload {
+        override fun getCursor(): String = this.id.toString()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.controller.router.design
 
 import com.kroffle.knitting.controller.handler.design.DesignHandler
+import com.kroffle.knitting.controller.handler.draftdesign.DraftDesignHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RequestPredicates.path
@@ -8,13 +9,14 @@ import org.springframework.web.reactive.function.server.RouterFunctions.nest
 import org.springframework.web.reactive.function.server.router
 
 @Configuration
-class DesignsRouter(private val handler: DesignHandler) {
+class DesignsRouter(private val designHandler: DesignHandler, private val draftDesignHandler: DraftDesignHandler) {
     @Bean
     fun designsRouterFunction() = nest(
         path(ROOT_PATH),
         router {
             listOf(
-                GET(GET_MY_DESIGNS_PATH, handler::getMyDesigns),
+                GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
+                GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
             )
         }
     )
@@ -22,6 +24,7 @@ class DesignsRouter(private val handler: DesignHandler) {
     companion object {
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/my"
+        private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/my"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/domain/draftdesign/entity/DraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/draftdesign/entity/DraftDesign.kt
@@ -1,5 +1,9 @@
 package com.kroffle.knitting.domain.draftdesign.entity
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import java.time.OffsetDateTime
 
 data class DraftDesign(
@@ -16,7 +20,12 @@ data class DraftDesign(
             updatedAt = OffsetDateTime.now(),
         )
 
+    val name: String?
+        get() = OBJECT_MAPPER.readValue<Value>(this.value).name
+
     companion object {
+        private val OBJECT_MAPPER = ObjectMapper()
+
         fun new(knitterId: Long, designId: Long?, value: String): DraftDesign =
             DraftDesign(
                 id = null,
@@ -27,4 +36,11 @@ data class DraftDesign(
                 updatedAt = OffsetDateTime.now(),
             )
     }
+
+    data class Value(
+        val name: String? = null,
+        @JsonAnySetter
+        @get:JsonAnyGetter
+        val truncated: MutableMap<String, Any> = sortedMapOf(),
+    )
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.kroffle.knitting.infra.persistence.draftdesign.entity.toDraftDesignEn
 import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.usecase.repository.DraftDesignRepository
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Repository
@@ -15,6 +16,11 @@ class DraftDesignRepositoryImpl(
         draftDesignRepository
             .findByIdAndKnitterId(id, knitterId)
             .switchIfEmpty(Mono.error(NotFoundEntity(DraftDesign::class.java)))
+            .map { it.toDraftDesign() }
+
+    override fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign> =
+        draftDesignRepository
+            .findByKnitterIdAndDesignId(knitterId, null)
             .map { it.toDraftDesign() }
 
     override fun save(draftDesign: DraftDesign): Mono<DraftDesign> =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
@@ -2,8 +2,10 @@ package com.kroffle.knitting.infra.persistence.draftdesign.repository
 
 import com.kroffle.knitting.infra.persistence.draftdesign.entity.DraftDesignEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 interface R2DBCDraftDesignRepository : ReactiveCrudRepository<DraftDesignEntity, Long> {
     fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesignEntity>
+    fun findByKnitterIdAndDesignId(knitterId: Long, designId: Long?): Flux<DraftDesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -4,6 +4,7 @@ import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
 import com.kroffle.knitting.usecase.draftdesign.dto.SaveDraftDesignData
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Service
@@ -44,8 +45,12 @@ class DraftDesignService(
         }
     }
 
+    fun getMyDraftDesigns(knitterId: Long): Flux<DraftDesign> =
+        draftDesignRepository.findNewDraftDesignsByKnitterId(knitterId)
+
     interface DraftDesignRepository {
         fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
+        fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign>
         fun save(draftDesign: DraftDesign): Mono<DraftDesign>
     }
 

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.router.design
 
 import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
+import com.kroffle.knitting.controller.handler.draftdesign.DraftDesignHandler
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
@@ -16,6 +17,7 @@ import com.kroffle.knitting.helper.extension.like
 import com.kroffle.knitting.infra.jwt.TokenDecoder
 import com.kroffle.knitting.infra.properties.WebApplicationProperties
 import com.kroffle.knitting.usecase.design.DesignService
+import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
 import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.repository.DraftDesignRepository
@@ -54,10 +56,14 @@ class DesignsRouterTest {
 
     @BeforeEach
     fun setUp() {
-        webClient = WebTestClientHelper.createWebTestClient(
-            DesignsRouter(DesignHandler(DesignService(designRepository, draftDesignRepository)))
-                .designsRouterFunction()
-        )
+        webClient = WebTestClientHelper
+            .createWebTestClient(
+                DesignsRouter(
+                    DesignHandler(DesignService(designRepository, draftDesignRepository)),
+                    DraftDesignHandler(DraftDesignService(draftDesignRepository, designRepository)),
+                )
+                    .designsRouterFunction()
+            )
     }
 
     @Test

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DraftDesignHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.kroffle.knitting.controller.router.design
+
+import com.kroffle.knitting.controller.handler.draftdesign.DraftDesignHandler
+import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
+import com.kroffle.knitting.helper.MockData
+import com.kroffle.knitting.helper.MockFactory
+import com.kroffle.knitting.helper.TestResponse
+import com.kroffle.knitting.helper.WebTestClientHelper
+import com.kroffle.knitting.helper.extension.addDefaultRequestHeader
+import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import reactor.core.publisher.Flux
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+@DisplayName("DraftDesignHandler Test")
+class DraftDesignHandlerTest : DescribeSpec() {
+    init {
+        val draftDesignService = mockk<DraftDesignService>()
+        val router = DesignsRouter(mockk(), DraftDesignHandler(draftDesignService))
+        val webClient = WebTestClientHelper
+            .createWebTestClient(router.designsRouterFunction())
+
+        afterContainer { clearAllMocks() }
+
+        describe("내 작성중인 도안 리스트 조회 test") {
+            val exchangeRequest = fun (): WebTestClient.ResponseSpec =
+                webClient
+                    .get()
+                    .uri("/designs/draft/my")
+                    .addDefaultRequestHeader()
+                    .exchange()
+
+            context("작성 중인 도안이 있는 경우") {
+                val updatedAt = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC)
+                val draftDesigns = listOf(
+                    MockFactory.create(
+                        MockData.DraftDesign(
+                            id = 1,
+                            value = "{\"name\": \"작성 중\"}",
+                            updatedAt = updatedAt,
+                        )
+                    ),
+                    MockFactory.create(
+                        MockData.DraftDesign(
+                            id = 2,
+                            value = "{\"id\": 1}",
+                            updatedAt = updatedAt,
+                        )
+                    ),
+                )
+                every {
+                    draftDesignService.getMyDraftDesigns(any())
+                } returns Flux.fromIterable(draftDesigns)
+
+                val response = exchangeRequest()
+                    .expectBody<TestResponse<List<MyDraftDesign.Response>>>()
+                    .returnResult()
+
+                it("service 를 통해 생성 요청해야 함") {
+                    verify(exactly = 1) {
+                        draftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                    }
+                }
+                it("작성중인 도안 리스트가 반환되어야 함") {
+                    response.status.is2xxSuccessful shouldBe true
+                    response.responseBody?.payload shouldBe listOf(
+                        MyDraftDesign.Response(
+                            id = 1,
+                            name = "작성 중",
+                            updatedAt = updatedAt,
+                        ),
+                        MyDraftDesign.Response(
+                            id = 2,
+                            name = null,
+                            updatedAt = updatedAt,
+                        )
+                    )
+                }
+            }
+
+            context("작성 중인 도안이 없는 경우") {
+                every {
+                    draftDesignService.getMyDraftDesigns(any())
+                } returns Flux.empty()
+
+                val response = exchangeRequest()
+                    .expectBody<TestResponse<List<MyDraftDesign.Response>>>()
+                    .returnResult()
+
+                it("service 를 통해 생성 요청해야 함") {
+                    verify(exactly = 1) {
+                        draftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                    }
+                }
+                it("작성중인 도안 리스트가 반환되어야 함") {
+                    response.status.is2xxSuccessful shouldBe true
+                    response.responseBody?.payload shouldBe emptyList<MyDraftDesign.Response>()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR 제안 사유
- 내가 작성 중인 도안의 리스트를 조회하는 API를 구현합니다.
- 이때 수정에 의해 생긴 임시저장 내역은 조회되지 않습니다.
- 자세한 API spec은 [postman](https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-0dc6a939-8005-4664-ac3d-33e105605ab7)에서 확인해주세요

Resolves ##1wfjzb9


## 주요 변경 기록
- DraftDesign에서 이름 조회할 수 있도록 property 추가
- 작성을 위해 생성된 임시저장 내역 조회 repository, service 구현
- 내가 작성중인 도안 리스트 조회 API 및 테스트 구현

## 언제 사용하면 되나요?
- 도안 생성 페이지에서 작성 중인 도안을 변경하고자 할 때, 리스트를 뿌려주면 됩니당.
![image](https://user-images.githubusercontent.com/26541456/146626776-cc59de06-7638-4e1d-9468-49c8c1d6e0ca.png)
- 여기에서 임시저장 글 불러오기 누르면 모달이 하나 뜰텐데 그 모달에 리스트를 뿌려주면 됩니다!