### PR TITLE
feat: API path 에서 my를 mine으로 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -23,8 +23,8 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
 
     companion object {
         private const val ROOT_PATH = "/designs"
-        private const val GET_MY_DESIGNS_PATH = "/my"
-        private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/my"
+        private const val GET_MY_DESIGNS_PATH = "/mine"
+        private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -106,7 +106,7 @@ class DesignsRouterTest {
         val responseBody: TestResponse<List<MyDesign.Response>> =
             webClient
                 .get()
-                .uri("/designs/my")
+                .uri("/designs/mine")
                 .addDefaultRequestHeader()
                 .exchange()
                 .expectStatus()
@@ -152,7 +152,7 @@ class DesignsRouterTest {
             .get()
             .uri { uriBuilder ->
                 uriBuilder
-                    .path("/designs/my")
+                    .path("/designs/mine")
                     .queryParam("count", "2")
                     .queryParam("after", "1")
                     .build()

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DraftDesignHandlerTest.kt
@@ -35,7 +35,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
             val exchangeRequest = fun (): WebTestClient.ResponseSpec =
                 webClient
                     .get()
-                    .uri("/designs/draft/my")
+                    .uri("/designs/draft/mine")
                     .addDefaultRequestHeader()
                     .exchange()
 


### PR DESCRIPTION
## PR 제안 사유
- 명사가 오는 것이 더 자연스러울 것 같아서 기존 api의 패스를 수정합니다.
- api path가 변경되면서 클라이언트에서도 수정이 필요합니다.

## 관련 postman
- https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-d2aa6c53-dc0b-43b6-9555-28bbcf574dca
- https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-0dc6a939-8005-4664-ac3d-33e105605ab7