### PR TITLE
feat: 도안 임시저장 상세 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.controller.handler.draftdesign
 
 import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
@@ -44,13 +45,29 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .getMyDraftDesigns(knitterId)
             .doOnError { ExceptionHelper.raiseException(it) }
             .map { draftDesign ->
-                MyDraftDesign.Response(
+                MyDraftDesigns.Response(
                     id = draftDesign.id!!,
                     name = draftDesign.name,
                     updatedAt = draftDesign.updatedAt!!,
                 )
             }
             .collect(Collectors.toList())
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
+    }
+
+    fun getMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(req)
+        val draftDesignId = req.pathVariable("id").toLong()
+        return service
+            .getMyDraftDesign(draftDesignId, knitterId)
+            .doOnError { ExceptionHelper.raiseException(it) }
+            .map { draftDesign ->
+                MyDraftDesign.Response(
+                    id = draftDesign.id!!,
+                    value = draftDesign.value,
+                    updatedAt = draftDesign.updatedAt!!,
+                )
+            }
             .flatMap { ResponseHelper.makeJsonResponse(it) }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesign.kt
@@ -1,14 +1,12 @@
 package com.kroffle.knitting.controller.handler.draftdesign.dto
 
-import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.OffsetDateTime
 
 object MyDraftDesign {
     data class Response(
-        val id: Long,
-        val name: String?,
-        val updatedAt: OffsetDateTime,
-    ) : ListItemPayload {
-        override fun getCursor(): String = this.id.toString()
-    }
+        val id: Long? = null,
+        val value: String,
+        val updatedAt: OffsetDateTime?,
+    ) : ObjectPayload
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesigns.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/MyDraftDesigns.kt
@@ -1,0 +1,14 @@
+package com.kroffle.knitting.controller.handler.draftdesign.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
+import java.time.OffsetDateTime
+
+object MyDraftDesigns {
+    data class Response(
+        val id: Long,
+        val name: String?,
+        val updatedAt: OffsetDateTime,
+    ) : ListItemPayload {
+        override fun getCursor(): String = this.id.toString()
+    }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -17,6 +17,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
             listOf(
                 GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
                 GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
+                GET(GET_MY_DRAFT_DESIGN_PATh, draftDesignHandler::getMyDraftDesign),
             )
         }
     )
@@ -25,6 +26,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/mine"
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
+        private const val GET_MY_DRAFT_DESIGN_PATh = "/draft/mine/{id}"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -48,6 +48,9 @@ class DraftDesignService(
     fun getMyDraftDesigns(knitterId: Long): Flux<DraftDesign> =
         draftDesignRepository.findNewDraftDesignsByKnitterId(knitterId)
 
+    fun getMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<DraftDesign> =
+        draftDesignRepository.findByIdAndKnitterId(draftDesignId, knitterId)
+
     interface DraftDesignRepository {
         fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
         fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign>

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -1,8 +1,8 @@
-package com.kroffle.knitting.controller.router.design
+package com.kroffle.knitting.controller.handler.draftdesign
 
-import com.kroffle.knitting.controller.handler.draftdesign.DraftDesignHandler
 import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesigns
+import com.kroffle.knitting.controller.router.design.DesignsRouter
 import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
 import com.kroffle.knitting.helper.MockData
 import com.kroffle.knitting.helper.MockFactory


### PR DESCRIPTION
## PR 제안 사유
- 작성 중인 도안 상세를 불러올 수 있는 API를 추가합니다.
- 수정 중인지, 생성 중인지 여부와는 관계없이 항상 불러옵니다.
- 자세한 API spec은 [postman](https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-dc652c8c-5775-43e0-86c9-5b58d4f8bb4d)에서 확인해주세요


Resolves #1wfjzcb

## 주요 변경 기록
- 도안 임시저장 상세 조회 API 구현
- 테스트 파일 위치 이동
- 기존 MyDraftDesign dto를 MyDraftDesigns로 변경