### PR TITLE
feat: DraftDesign 삭제 API 구현

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -1,5 +1,6 @@
 package com.kroffle.knitting.controller.handler.draftdesign
 
+import com.kroffle.knitting.controller.handler.draftdesign.dto.DeleteDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
@@ -68,6 +69,16 @@ class DraftDesignHandler(private val service: DraftDesignService) {
                     updatedAt = draftDesign.updatedAt!!,
                 )
             }
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
+    }
+
+    fun deleteMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(req)
+        val draftDesignId = req.pathVariable("id").toLong()
+        return service
+            .deleteMyDraftDesign(draftDesignId, knitterId)
+            .doOnError { ExceptionHelper.raiseException(it) }
+            .map { deletedId -> DeleteDraftDesign.Response(id = deletedId) }
             .flatMap { ResponseHelper.makeJsonResponse(it) }
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.controller.handler.draftdesign
 
 import com.kroffle.knitting.controller.handler.draftdesign.dto.DeleteDraftDesign
-import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
-import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesigns
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
@@ -46,7 +46,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .getMyDraftDesigns(knitterId)
             .doOnError { ExceptionHelper.raiseException(it) }
             .map { draftDesign ->
-                MyDraftDesigns.Response(
+                GetMyDraftDesigns.Response(
                     id = draftDesign.id!!,
                     name = draftDesign.name,
                     updatedAt = draftDesign.updatedAt!!,
@@ -63,7 +63,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .getMyDraftDesign(draftDesignId, knitterId)
             .doOnError { ExceptionHelper.raiseException(it) }
             .map { draftDesign ->
-                MyDraftDesign.Response(
+                GetMyDraftDesign.Response(
                     id = draftDesign.id!!,
                     value = draftDesign.value,
                     updatedAt = draftDesign.updatedAt!!,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/DeleteDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/DeleteDraftDesign.kt
@@ -1,0 +1,9 @@
+package com.kroffle.knitting.controller.handler.draftdesign.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+
+object DeleteDraftDesign {
+    data class Response(
+        val id: Long,
+    ) : ObjectPayload
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesign.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.controller.handler.draftdesign.dto
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.OffsetDateTime
 
-object MyDraftDesign {
+object GetMyDraftDesign {
     data class Response(
         val id: Long? = null,
         val value: String,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesigns.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesigns.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.controller.handler.draftdesign.dto
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
 import java.time.OffsetDateTime
 
-object MyDraftDesigns {
+object GetMyDraftDesigns {
     data class Response(
         val id: Long,
         val name: String?,

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
@@ -19,7 +19,8 @@ class DesignRouter(
         router {
             listOf(
                 POST(CREATE_DESIGN_PATH, designHandler::createDesign),
-                POST(SAVE_DRAFT_PATH, draftDesignHandler::saveDraft)
+                POST(SAVE_DRAFT_PATH, draftDesignHandler::saveDraft),
+                DELETE(DELETE_MY_DRAFT_DESIGN_PATH, draftDesignHandler::deleteMyDraftDesign),
             )
         }
     )
@@ -28,6 +29,7 @@ class DesignRouter(
         private const val ROOT_PATH = "/design"
         private const val CREATE_DESIGN_PATH = ""
         private const val SAVE_DRAFT_PATH = "/draft"
+        private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{id}"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.kroffle.knitting.usecase.repository.DraftDesignRepository
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
 
 @Repository
 class DraftDesignRepositoryImpl(
@@ -29,5 +30,8 @@ class DraftDesignRepositoryImpl(
             .map { it.toDraftDesign() }
 
     override fun delete(draftDesign: DraftDesign): Mono<Long> =
-        draftDesignRepository.delete(draftDesign.toDraftDesignEntity()).map { draftDesign.id }
+        draftDesignRepository
+            .delete(draftDesign.toDraftDesignEntity())
+            .flatMap { Mono.just(draftDesign.id!!) }
+            .switchIfEmpty { Mono.just(draftDesign.id!!) }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -51,10 +51,18 @@ class DraftDesignService(
     fun getMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<DraftDesign> =
         draftDesignRepository.findByIdAndKnitterId(draftDesignId, knitterId)
 
+    fun deleteMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<Long> {
+        val draftDesign = draftDesignRepository
+            .findByIdAndKnitterId(draftDesignId, knitterId)
+        return draftDesign
+            .flatMap { draftDesignRepository.delete(it) }
+    }
+
     interface DraftDesignRepository {
         fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
         fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign>
         fun save(draftDesign: DraftDesign): Mono<DraftDesign>
+        fun delete(draftDesign: DraftDesign): Mono<Long>
     }
 
     interface DesignRepository {

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -1,8 +1,8 @@
 package com.kroffle.knitting.controller.handler.draftdesign
 
 import com.kroffle.knitting.controller.handler.draftdesign.dto.DeleteDraftDesign
-import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesign
-import com.kroffle.knitting.controller.handler.draftdesign.dto.MyDraftDesigns
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
 import com.kroffle.knitting.controller.router.design.DesignRouter
 import com.kroffle.knitting.controller.router.design.DesignsRouter
 import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
@@ -71,7 +71,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                 } returns Flux.fromIterable(draftDesigns)
 
                 val response = exchangeRequest()
-                    .expectBody<TestResponse<List<MyDraftDesigns.Response>>>()
+                    .expectBody<TestResponse<List<GetMyDraftDesigns.Response>>>()
                     .returnResult()
 
                 it("service 를 통해 생성 요청해야 함") {
@@ -82,12 +82,12 @@ class DraftDesignHandlerTest : DescribeSpec() {
                 it("작성중인 도안 리스트가 반환되어야 함") {
                     response.status.is2xxSuccessful shouldBe true
                     response.responseBody?.payload shouldBe listOf(
-                        MyDraftDesigns.Response(
+                        GetMyDraftDesigns.Response(
                             id = 1,
                             name = "작성 중",
                             updatedAt = updatedAt,
                         ),
-                        MyDraftDesigns.Response(
+                        GetMyDraftDesigns.Response(
                             id = 2,
                             name = null,
                             updatedAt = updatedAt,
@@ -102,7 +102,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                 } returns Flux.empty()
 
                 val response = exchangeRequest()
-                    .expectBody<TestResponse<List<MyDraftDesigns.Response>>>()
+                    .expectBody<TestResponse<List<GetMyDraftDesigns.Response>>>()
                     .returnResult()
 
                 it("service 를 통해 생성 요청해야 함") {
@@ -139,7 +139,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                 } returns Mono.just(draftDesign)
 
                 val response = exchangeRequest()
-                    .expectBody<TestResponse<MyDraftDesign.Response>>()
+                    .expectBody<TestResponse<GetMyDraftDesign.Response>>()
                     .returnResult()
 
                 it("service 를 통해 생성 요청해야 함") {
@@ -149,7 +149,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     }
                 }
                 it("작성중인 도안이 반환되어야 함") {
-                    val expectedResponse = MyDraftDesign.Response(
+                    val expectedResponse = GetMyDraftDesign.Response(
                         id = 1,
                         value = "{\"name\": \"작성 중\"}",
                         updatedAt = updatedAt,
@@ -165,7 +165,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
 
                 val response = exchangeRequest()
-                    .expectBody<TestResponse<MyDraftDesign.Response>>()
+                    .expectBody<TestResponse<GetMyDraftDesign.Response>>()
                     .returnResult()
 
                 it("service 를 통해 생성 요청해야 함") {


### PR DESCRIPTION
## PR 제안 사유
- 임시저장 내역을 삭제할 수 있는 API를 추가합니다.


## 주요 변경 기록
- dto 이름에 Method prefix를 붙여 더 구분하기 쉽도록 만들었습니다.
- delete method가 empty를 리턴하고 있었는데, id를 제대로 리턴할 수 있도록 수정합니다.
- 임시저장 내역을 삭제 할 수 있는 API를 구현합니다.

## 어디에서 사용하나요?
- 임시저장 글 불러오기 클릭시 나오는 모달에 뿌려주는 임시저장내역 리스트에서 삭제할 수 있게 해줍니다.
![image](https://user-images.githubusercontent.com/26541456/146628528-ad2f5931-d588-4560-ae8b-1fd2793bb418.png)
- 상품 수정 -> 수정 내역이 있어 수정중이던 내역을 불러올 것인지 물어보는 모달 -> 불러오지 않는 것을 선택
  - 위 케이스에서 중복으로 수정 내역이 쌓이지 않도록 삭제해줍니다.

