### PR TITLE
test: 임시저장 handler, service 단위테스트 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -5,6 +5,7 @@ import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
+import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
@@ -19,9 +20,9 @@ import java.util.stream.Collectors
 @Component
 class DraftDesignHandler(private val service: DraftDesignService) {
     fun saveDraft(req: ServerRequest): Mono<ServerResponse> {
-        // TODO: Add unit test
         val body: Mono<SaveDraftDesign.Request> = req
             .bodyToMono(SaveDraftDesign.Request::class.java)
+            .onErrorResume { Mono.error(InvalidBodyException()) }
             .switchIfEmpty(Mono.error(EmptyBodyException()))
         val knitterId = AuthHelper.getKnitterId(req)
         return body
@@ -36,6 +37,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
                         )
                     )
             }
+            .doOnError { ExceptionHelper.raiseException(it) }
             .map { SaveDraftDesign.Response(it.id!!) }
             .flatMap { ResponseHelper.makeJsonResponse(it) }
     }

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandlerTest.kt
@@ -1,9 +1,9 @@
-package com.kroffle.knitting.controller.router.design
+package com.kroffle.knitting.controller.handler.design
 
-import com.kroffle.knitting.controller.handler.design.DesignHandler
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
+import com.kroffle.knitting.controller.router.design.DesignRouter
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -34,9 +34,9 @@ import java.time.ZoneOffset
 @DisplayName("DraftDesignHandler Test")
 class DraftDesignHandlerTest : DescribeSpec() {
     init {
-        val draftDesignService = mockk<DraftDesignService>()
-        val designsRouter = DesignsRouter(mockk(), DraftDesignHandler(draftDesignService))
-        val designRouter = DesignRouter(mockk(), DraftDesignHandler(draftDesignService))
+        val mockDraftDesignService = mockk<DraftDesignService>()
+        val designsRouter = DesignsRouter(mockk(), DraftDesignHandler(mockDraftDesignService))
+        val designRouter = DesignRouter(mockk(), DraftDesignHandler(mockDraftDesignService))
         val designsWebclient = WebTestClientHelper
             .createWebTestClient(designsRouter.designsRouterFunction())
         val designWebclient = WebTestClientHelper
@@ -56,7 +56,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
             context("정상적인 도안 생성을 요청한 경우") {
                 val mockDraftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
                 every {
-                    draftDesignService.saveDraft(any())
+                    mockDraftDesignService.saveDraft(any())
                 } returns Mono.just(mockDraftDesign)
                 val requestBody = """
                 {
@@ -71,7 +71,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService.saveDraft(
+                        mockDraftDesignService.saveDraft(
                             SaveDraftDesignData(
                                 id = 1,
                                 knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
@@ -138,7 +138,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     ),
                 )
                 every {
-                    draftDesignService.getMyDraftDesigns(any())
+                    mockDraftDesignService.getMyDraftDesigns(any())
                 } returns Flux.fromIterable(draftDesigns)
 
                 val response = exchangeRequest()
@@ -147,7 +147,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                        mockDraftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
                 it("작성중인 도안 리스트가 반환되어야 함") {
@@ -169,7 +169,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
             context("작성 중인 도안이 없는 경우") {
                 every {
-                    draftDesignService.getMyDraftDesigns(any())
+                    mockDraftDesignService.getMyDraftDesigns(any())
                 } returns Flux.empty()
 
                 val response = exchangeRequest()
@@ -178,7 +178,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                        mockDraftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
                 it("빈 리스트가 반환되어야 함") {
@@ -206,7 +206,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     )
                 )
                 every {
-                    draftDesignService.getMyDraftDesign(any(), any())
+                    mockDraftDesignService.getMyDraftDesign(any(), any())
                 } returns Mono.just(draftDesign)
 
                 val response = exchangeRequest()
@@ -215,7 +215,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService
+                        mockDraftDesignService
                             .getMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
@@ -232,7 +232,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
             context("작성 중인 도안이 없는 경우") {
                 every {
-                    draftDesignService.getMyDraftDesign(any(), any())
+                    mockDraftDesignService.getMyDraftDesign(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
 
                 val response = exchangeRequest()
@@ -241,7 +241,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService.getMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                        mockDraftDesignService.getMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
                 it("NOT FOUND 에러가 발생되어야 함") {
@@ -260,7 +260,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
             context("작성 중인 도안이 있는 경우") {
                 every {
-                    draftDesignService.deleteMyDraftDesign(any(), any())
+                    mockDraftDesignService.deleteMyDraftDesign(any(), any())
                 } returns Mono.just(1)
 
                 val response = exchangeRequest()
@@ -269,7 +269,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService
+                        mockDraftDesignService
                             .deleteMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
@@ -282,7 +282,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
             context("작성 중인 도안이 없는 경우") {
                 every {
-                    draftDesignService.deleteMyDraftDesign(any(), any())
+                    mockDraftDesignService.deleteMyDraftDesign(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
 
                 val response = exchangeRequest()
@@ -291,7 +291,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
                 it("service 를 통해 생성 요청해야 함") {
                     verify(exactly = 1) {
-                        draftDesignService.deleteMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
+                        mockDraftDesignService.deleteMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
                 }
                 it("NOT FOUND 에러가 발생되어야 함") {

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -28,7 +28,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
         Given("내가 작성 중이던 도안이 존재하고") {
             val mockDraftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
 
-            When("작성 중이던 도안리스트를 조회하면") {
+            When("작성 중이던 도안리스트를 요청하면") {
                 every {
                     mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
                 } returns Flux.fromIterable(listOf(mockDraftDesign))
@@ -45,7 +45,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
             }
 
-            When("작성 중이던 도안 상세를 조회하면") {
+            When("작성 중이던 도안 상세를 요청하면") {
                 every {
                     mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
                 } returns Mono.just(mockDraftDesign)
@@ -61,7 +61,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
             }
 
-            When("작성 중이던 도안을 삭제하면") {
+            When("작성 중이던 도안을 삭제 요청하면") {
                 every {
                     mockDraftDesignRepository
                         .findByIdAndKnitterId(any(), any())
@@ -90,7 +90,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
         }
 
         Given("내가 작성 중이던 도안이 존재하지 않고") {
-            When("작성 중이던 도안리스트를 조회하면") {
+            When("작성 중이던 도안리스트를 요청하면") {
                 every {
                     mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
                 } returns Flux.empty()
@@ -106,7 +106,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
             }
 
-            When("작성 중이던 도안 상세를 조회하면") {
+            When("작성 중이던 도안 상세를 요청하면") {
                 every {
                     mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
@@ -123,7 +123,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
             }
 
-            When("작성 중이던 도안을 삭제하면") {
+            When("작성 중이던 도안을 삭제 요청하면") {
                 every {
                     mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -1,0 +1,329 @@
+package com.kroffle.knitting.usecase.draftdesign
+
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
+import com.kroffle.knitting.helper.MockData
+import com.kroffle.knitting.helper.MockFactory
+import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
+import com.kroffle.knitting.usecase.draftdesign.dto.SaveDraftDesignData
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.expectError
+import reactor.kotlin.test.test
+
+class DraftDesignServiceTest : BehaviorSpec() {
+    init {
+        val mockDraftDesignRepository = mockk<DraftDesignService.DraftDesignRepository>()
+        val mockDesignRepository = mockk<DraftDesignService.DesignRepository>()
+        val service = DraftDesignService(mockDraftDesignRepository, mockDesignRepository)
+
+        afterContainer { clearAllMocks() }
+
+        Given("내가 작성 중이던 도안이 존재하고") {
+            val mockDraftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
+
+            When("작성 중이던 도안리스트를 조회하면") {
+                every {
+                    mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
+                } returns Flux.fromIterable(listOf(mockDraftDesign))
+
+                val result = service.getMyDraftDesigns(1).collectList().block()
+                Then("작성 중이던 도안 목록을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository
+                            .findNewDraftDesignsByKnitterId(1)
+                    }
+                }
+                Then("작성 중이던 도안 리스트가 반환되어야 한다") {
+                    result shouldBe listOf(mockDraftDesign)
+                }
+            }
+
+            When("작성 중이던 도안 상세를 조회하면") {
+                every {
+                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.getMyDraftDesign(1, 1).block()
+                Then("작성 중이던 도안을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("작성 중이던 도안 상세가 반환되어야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+
+            When("작성 중이던 도안을 삭제하면") {
+                every {
+                    mockDraftDesignRepository
+                        .findByIdAndKnitterId(any(), any())
+                } returns Mono.just(mockDraftDesign)
+
+                every {
+                    mockDraftDesignRepository.delete(any())
+                } returns Mono.just(1)
+
+                val result = service.deleteMyDraftDesign(1, 1).block()
+
+                Then("작성 중이던 도안을 조회해야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("작성 중이던 도안을 삭제해야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.delete(mockDraftDesign)
+                    }
+                }
+                Then("삭제된 도안 id가 반환되어야 한다") {
+                    result shouldBe mockDraftDesign.id
+                }
+            }
+        }
+
+        Given("내가 작성 중이던 도안이 존재하지 않고") {
+            When("작성 중이던 도안리스트를 조회하면") {
+                every {
+                    mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
+                } returns Flux.empty()
+
+                val result = service.getMyDraftDesigns(1).collectList().block()
+                Then("작성 중이던 도안 목록을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findNewDraftDesignsByKnitterId(1)
+                    }
+                }
+                Then("빈 리스트가 반환되어야 한다") {
+                    result shouldBe emptyList()
+                }
+            }
+
+            When("작성 중이던 도안 상세를 조회하면") {
+                every {
+                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
+
+                val result = service.deleteMyDraftDesign(1, 1).test()
+
+                Then("작성 중이던 도안을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("NotFoundEntity exception 이 발생해야 한다") {
+                    result.expectError(NotFoundEntity::class).verify()
+                }
+            }
+
+            When("작성 중이던 도안을 삭제하면") {
+                every {
+                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
+
+                val result = service.deleteMyDraftDesign(1, 1).test()
+
+                Then("작성 중이던 도안을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+
+                Then("작성 중이던 도안을 삭제요청 하지 않는다") {
+                    verify(inverse = true) {
+                        mockDraftDesignRepository.delete(any())
+                    }
+                }
+
+                Then("NotFoundEntity exception 이 발생해야 한다") {
+                    result.expectError(NotFoundEntity::class).verify()
+                }
+            }
+        }
+
+        Given("새로운 도안을 생성 중인 임시저장 내역이 주어지고") {
+            val designId = null
+            val mockDraftDesign = MockFactory.create(
+                MockData.DraftDesign(
+                    id = 1,
+                    value = "\"name\": \"도안 이름\""
+                )
+            )
+            When("기존에 저장된 이력이 없는 경우") {
+                val draftDesignId = null
+                val data = SaveDraftDesignData(
+                    id = draftDesignId,
+                    knitterId = 1,
+                    designId = designId,
+                    value = "\"name\": \"도안 이름\"",
+                )
+                val saveArgument = slot<DraftDesign>()
+                every {
+                    mockDraftDesignRepository.save(capture(saveArgument))
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.saveDraft(data).block()
+                Then("새로운 임시저장 내역을 생성해야 한다") {
+                    saveArgument.isCaptured shouldBe true
+                    with(saveArgument.captured) {
+                        id shouldBe null
+                        knitterId shouldBe 1
+                        designId shouldBe null
+                        value shouldBe "\"name\": \"도안 이름\""
+                    }
+                }
+                Then("생성된 임시저장 내역을 반환해야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+
+            When("기존에 저장된 이력이 있는 경우") {
+                val draftDesignId = 1L
+                val beforeDraftDesign = MockFactory.create(
+                    MockData.DraftDesign(id = draftDesignId)
+                )
+                val data = SaveDraftDesignData(
+                    id = draftDesignId,
+                    knitterId = 1,
+                    designId = designId,
+                    value = "\"name\": \"도안 이름\"",
+                )
+                val saveArgument = slot<DraftDesign>()
+
+                every {
+                    mockDraftDesignRepository
+                        .findByIdAndKnitterId(any(), any())
+                } returns Mono.just(beforeDraftDesign)
+
+                every {
+                    mockDraftDesignRepository.save(capture(saveArgument))
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.saveDraft(data).block()
+                Then("기존 임시저장 내역을 조회해야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("기존 임시저장 내역을 수정하여 저장해야 한다") {
+                    saveArgument.isCaptured shouldBe true
+                    with(saveArgument.captured) {
+                        id shouldBe 1
+                        knitterId shouldBe 1
+                        designId shouldBe null
+                        value shouldBe "\"name\": \"도안 이름\""
+                    }
+                }
+                Then("생성된 임시저장 내역을 반환해야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+        }
+
+        Given("기존 도안을 수정 중인 임시저장 내역이 주어지고") {
+            val designId = 1L
+            val mockDesign = MockFactory.create(MockData.Design(id = 1))
+            val mockDraftDesign = MockFactory.create(
+                MockData.DraftDesign(
+                    id = 1,
+                    value = "\"name\": \"도안 이름\""
+                )
+            )
+            When("기존에 저장된 이력이 없는 경우") {
+                val draftDesignId = null
+                val data = SaveDraftDesignData(
+                    id = draftDesignId,
+                    knitterId = 1,
+                    designId = designId,
+                    value = "\"name\": \"도안 이름\"",
+                )
+                val saveArgument = slot<DraftDesign>()
+
+                every {
+                    mockDesignRepository.findByIdAndKnitterId(any(), any())
+                } returns Mono.just(mockDesign)
+
+                every {
+                    mockDraftDesignRepository.save(capture(saveArgument))
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.saveDraft(data).block()
+                Then("존재하는 도안인지 검증해야 한다") {
+                    verify(exactly = 1) {
+                        mockDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("새로운 임시저장 내역을 생성해야 한다") {
+                    saveArgument.isCaptured shouldBe true
+                    with(saveArgument.captured) {
+                        id shouldBe null
+                        knitterId shouldBe 1
+                        designId shouldBe 1
+                        value shouldBe "\"name\": \"도안 이름\""
+                    }
+                }
+                Then("생성된 임시저장 내역을 반환해야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+
+            When("기존에 저장된 이력이 있는 경우") {
+                val draftDesignId = 1L
+                val beforeDraftDesign = MockFactory.create(
+                    MockData.DraftDesign(id = draftDesignId)
+                )
+                val data = SaveDraftDesignData(
+                    id = draftDesignId,
+                    knitterId = 1,
+                    designId = designId,
+                    value = "\"name\": \"도안 이름\"",
+                )
+                val saveArgument = slot<DraftDesign>()
+
+                every {
+                    mockDesignRepository.findByIdAndKnitterId(any(), any())
+                } returns Mono.just(mockDesign)
+
+                every {
+                    mockDraftDesignRepository
+                        .findByIdAndKnitterId(any(), any())
+                } returns Mono.just(beforeDraftDesign)
+
+                every {
+                    mockDraftDesignRepository.save(capture(saveArgument))
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.saveDraft(data).block()
+                Then("존재하는 도안인지 검증해야 한다") {
+                    verify(exactly = 1) {
+                        mockDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("기존 임시저장 내역을 조회해야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                    }
+                }
+                Then("기존 임시저장 내역을 수정하여 저장해야 한다") {
+                    saveArgument.isCaptured shouldBe true
+                    with(saveArgument.captured) {
+                        id shouldBe 1
+                        knitterId shouldBe 1
+                        designId shouldBe 1
+                        value shouldBe "\"name\": \"도안 이름\""
+                    }
+                }
+                Then("생성된 임시저장 내역을 반환해야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR 제안 사유
- 누락된 단위테스트를 추가합니다.

## 주요 변경 기록
- DraftDesignService 에 대한 단위테스트를 추가합니다.
- DraftDesign 저장 API handler에 대한 단위테스트를 추가합니다.
  - 테스트를 작성하며 발견된 에러 핸들링 누락 부분을 수정합니다.
-  테스트 파일을 적절한 위치로 옮겨줍니다.
- mockk 인스턴스 이름에 mock prefix를 붙여줍니다.