### PR TITLE
feat: 도안 수정 중인 내역 조회 API 구현 

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -61,7 +61,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
 
     fun getMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(req)
-        val draftDesignId = req.pathVariable("id").toLong()
+        val draftDesignId = req.pathVariable("draftDesignId").toLong()
         return service
             .getMyDraftDesign(draftDesignId, knitterId)
             .doOnError { ExceptionHelper.raiseException(it) }
@@ -93,7 +93,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
 
     fun deleteMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(req)
-        val draftDesignId = req.pathVariable("id").toLong()
+        val draftDesignId = req.pathVariable("draftDesignId").toLong()
         return service
             .deleteMyDraftDesign(draftDesignId, knitterId)
             .doOnError { ExceptionHelper.raiseException(it) }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.handler.draftdesign
 
 import com.kroffle.knitting.controller.handler.draftdesign.dto.DeleteDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesignToUpdate
 import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
@@ -66,6 +67,22 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .doOnError { ExceptionHelper.raiseException(it) }
             .map { draftDesign ->
                 GetMyDraftDesign.Response(
+                    id = draftDesign.id!!,
+                    value = draftDesign.value,
+                    updatedAt = draftDesign.updatedAt!!,
+                )
+            }
+            .flatMap { ResponseHelper.makeJsonResponse(it) }
+    }
+
+    fun getMyDraftDesignToUpdate(req: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(req)
+        val designId = req.pathVariable("designId").toLong()
+        return service
+            .getMyDraftDesignToUpdate(designId = designId, knitterId = knitterId)
+            .doOnError { ExceptionHelper.raiseException(it) }
+            .map { draftDesign ->
+                GetMyDraftDesignToUpdate.Response(
                     id = draftDesign.id!!,
                     value = draftDesign.value,
                     updatedAt = draftDesign.updatedAt!!,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesign.kt
@@ -5,8 +5,8 @@ import java.time.OffsetDateTime
 
 object GetMyDraftDesign {
     data class Response(
-        val id: Long? = null,
+        val id: Long,
         val value: String,
-        val updatedAt: OffsetDateTime?,
+        val updatedAt: OffsetDateTime,
     ) : ObjectPayload
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesignToUpdate.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/GetMyDraftDesignToUpdate.kt
@@ -1,0 +1,12 @@
+package com.kroffle.knitting.controller.handler.draftdesign.dto
+
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+import java.time.OffsetDateTime
+
+object GetMyDraftDesignToUpdate {
+    data class Response(
+        val id: Long,
+        val value: String,
+        val updatedAt: OffsetDateTime,
+    ) : ObjectPayload
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -119,7 +119,7 @@ class ProductHandler(private val productService: ProductService) {
 
     fun getMyProduct(req: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(req)
-        val productId = req.pathVariable("id").toLong()
+        val productId = req.pathVariable("productId").toLong()
         val product: Mono<Product> =
             productService.get(
                 GetMyProductData(

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
@@ -29,7 +29,7 @@ class DesignRouter(
         private const val ROOT_PATH = "/design"
         private const val CREATE_DESIGN_PATH = ""
         private const val SAVE_DRAFT_PATH = "/draft"
-        private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{id}"
+        private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
         val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -18,6 +18,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
                 GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
                 GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
                 GET(GET_MY_DRAFT_DESIGN_PATH, draftDesignHandler::getMyDraftDesign),
+                GET(GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH, draftDesignHandler::getMyDraftDesignToUpdate),
             )
         }
     )
@@ -27,6 +28,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
         private const val GET_MY_DESIGNS_PATH = "/mine"
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
         private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{id}"
+        private const val GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH = "/{designId}/draft/mine"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -17,7 +17,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
             listOf(
                 GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
                 GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
-                GET(GET_MY_DRAFT_DESIGN_PATh, draftDesignHandler::getMyDraftDesign),
+                GET(GET_MY_DRAFT_DESIGN_PATH, draftDesignHandler::getMyDraftDesign),
             )
         }
     )
@@ -26,7 +26,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/mine"
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
-        private const val GET_MY_DRAFT_DESIGN_PATh = "/draft/mine/{id}"
+        private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{id}"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -27,7 +27,7 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
         private const val ROOT_PATH = "/designs"
         private const val GET_MY_DESIGNS_PATH = "/mine"
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
-        private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{id}"
+        private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
         private const val GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH = "/{designId}/draft/mine"
         val PUBLIC_PATHS: List<String> = listOf()
     }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/product/ProductRouter.kt
@@ -28,7 +28,7 @@ class ProductRouter(private val handler: ProductHandler) {
         private const val ROOT_PATH = "/product"
         private const val DRAFT_PRODUCT_PACKAGE_PATH = "/package"
         private const val DRAFT_PRODUCT_CONTENT_PATH = "/content"
-        private const val GET_MY_PRODUCT_PATH = "/mine/{id}"
+        private const val GET_MY_PRODUCT_PATH = "/mine/{productId}"
         private const val GET_MY_PRODUCTS_PATH = "/mine"
         val PUBLIC_PATHS = listOf<String>()
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -24,6 +24,12 @@ class DraftDesignRepositoryImpl(
             .findByKnitterIdAndDesignId(knitterId, null)
             .map { it.toDraftDesign() }
 
+    override fun getDraftDesignToUpdate(designId: Long, knitterId: Long): Mono<DraftDesign> =
+        draftDesignRepository
+            .getByKnitterIdAndDesignId(knitterId = knitterId, designId = designId)
+            .switchIfEmpty(Mono.error(NotFoundEntity(DraftDesign::class.java)))
+            .map { it.toDraftDesign() }
+
     override fun save(draftDesign: DraftDesign): Mono<DraftDesign> =
         draftDesignRepository
             .save(draftDesign.toDraftDesignEntity())

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -19,7 +19,7 @@ class DraftDesignRepositoryImpl(
             .switchIfEmpty(Mono.error(NotFoundEntity(DraftDesign::class.java)))
             .map { it.toDraftDesign() }
 
-    override fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign> =
+    override fun findDraftDesignsToCreateByKnitterId(knitterId: Long): Flux<DraftDesign> =
         draftDesignRepository
             .findByKnitterIdAndDesignId(knitterId, null)
             .map { it.toDraftDesign() }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/DraftDesignRepositoryImpl.kt
@@ -13,13 +13,13 @@ import reactor.kotlin.core.publisher.switchIfEmpty
 class DraftDesignRepositoryImpl(
     private val draftDesignRepository: R2DBCDraftDesignRepository,
 ) : DraftDesignRepository {
-    override fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign> =
+    override fun getDraftDesign(id: Long, knitterId: Long): Mono<DraftDesign> =
         draftDesignRepository
             .findByIdAndKnitterId(id, knitterId)
             .switchIfEmpty(Mono.error(NotFoundEntity(DraftDesign::class.java)))
             .map { it.toDraftDesign() }
 
-    override fun findDraftDesignsToCreateByKnitterId(knitterId: Long): Flux<DraftDesign> =
+    override fun findDraftDesignsToCreate(knitterId: Long): Flux<DraftDesign> =
         draftDesignRepository
             .findByKnitterIdAndDesignId(knitterId, null)
             .map { it.toDraftDesign() }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/draftdesign/repository/R2DBCDraftDesignRepository.kt
@@ -8,4 +8,5 @@ import reactor.core.publisher.Mono
 interface R2DBCDraftDesignRepository : ReactiveCrudRepository<DraftDesignEntity, Long> {
     fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesignEntity>
     fun findByKnitterIdAndDesignId(knitterId: Long, designId: Long?): Flux<DraftDesignEntity>
+    fun getByKnitterIdAndDesignId(knitterId: Long, designId: Long): Mono<DraftDesignEntity>
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/DesignService.kt
@@ -44,7 +44,7 @@ class DesignService(
             createDesign(data)
                 .flatMap { design ->
                     draftDesignRepository
-                        .findByIdAndKnitterId(
+                        .getDraftDesign(
                             id = data.draftId,
                             knitterId = data.knitterId,
                         )
@@ -71,7 +71,7 @@ class DesignService(
     }
 
     interface DraftDesignRepository {
-        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
+        fun getDraftDesign(id: Long, knitterId: Long): Mono<DraftDesign>
         fun delete(draftDesign: DraftDesign): Mono<Long>
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -28,7 +28,7 @@ class DraftDesignService(
             )
         } else {
             draftDesignRepository
-                .findByIdAndKnitterId(data.id, data.knitterId)
+                .getDraftDesign(data.id, data.knitterId)
                 .map { it.merge(data.value) }
                 .flatMap {
                     draftDesignRepository.save(it)
@@ -46,10 +46,10 @@ class DraftDesignService(
     }
 
     fun getMyDraftDesigns(knitterId: Long): Flux<DraftDesign> =
-        draftDesignRepository.findDraftDesignsToCreateByKnitterId(knitterId)
+        draftDesignRepository.findDraftDesignsToCreate(knitterId)
 
     fun getMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<DraftDesign> =
-        draftDesignRepository.findByIdAndKnitterId(
+        draftDesignRepository.getDraftDesign(
             id = draftDesignId,
             knitterId = knitterId,
         )
@@ -62,14 +62,14 @@ class DraftDesignService(
 
     fun deleteMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<Long> {
         val draftDesign = draftDesignRepository
-            .findByIdAndKnitterId(draftDesignId, knitterId)
+            .getDraftDesign(draftDesignId, knitterId)
         return draftDesign
             .flatMap { draftDesignRepository.delete(it) }
     }
 
     interface DraftDesignRepository {
-        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
-        fun findDraftDesignsToCreateByKnitterId(knitterId: Long): Flux<DraftDesign>
+        fun getDraftDesign(id: Long, knitterId: Long): Mono<DraftDesign>
+        fun findDraftDesignsToCreate(knitterId: Long): Flux<DraftDesign>
         fun getDraftDesignToUpdate(designId: Long, knitterId: Long): Mono<DraftDesign>
         fun save(draftDesign: DraftDesign): Mono<DraftDesign>
         fun delete(draftDesign: DraftDesign): Mono<Long>

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -49,7 +49,16 @@ class DraftDesignService(
         draftDesignRepository.findDraftDesignsToCreateByKnitterId(knitterId)
 
     fun getMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<DraftDesign> =
-        draftDesignRepository.findByIdAndKnitterId(draftDesignId, knitterId)
+        draftDesignRepository.findByIdAndKnitterId(
+            id = draftDesignId,
+            knitterId = knitterId,
+        )
+
+    fun getMyDraftDesignToUpdate(designId: Long, knitterId: Long): Mono<DraftDesign> =
+        draftDesignRepository.getDraftDesignToUpdate(
+            designId = designId,
+            knitterId = knitterId,
+        )
 
     fun deleteMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<Long> {
         val draftDesign = draftDesignRepository
@@ -61,6 +70,7 @@ class DraftDesignService(
     interface DraftDesignRepository {
         fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
         fun findDraftDesignsToCreateByKnitterId(knitterId: Long): Flux<DraftDesign>
+        fun getDraftDesignToUpdate(designId: Long, knitterId: Long): Mono<DraftDesign>
         fun save(draftDesign: DraftDesign): Mono<DraftDesign>
         fun delete(draftDesign: DraftDesign): Mono<Long>
     }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -46,7 +46,7 @@ class DraftDesignService(
     }
 
     fun getMyDraftDesigns(knitterId: Long): Flux<DraftDesign> =
-        draftDesignRepository.findNewDraftDesignsByKnitterId(knitterId)
+        draftDesignRepository.findDraftDesignsToCreateByKnitterId(knitterId)
 
     fun getMyDraftDesign(draftDesignId: Long, knitterId: Long): Mono<DraftDesign> =
         draftDesignRepository.findByIdAndKnitterId(draftDesignId, knitterId)
@@ -60,7 +60,7 @@ class DraftDesignService(
 
     interface DraftDesignRepository {
         fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<DraftDesign>
-        fun findNewDraftDesignsByKnitterId(knitterId: Long): Flux<DraftDesign>
+        fun findDraftDesignsToCreateByKnitterId(knitterId: Long): Flux<DraftDesign>
         fun save(draftDesign: DraftDesign): Mono<DraftDesign>
         fun delete(draftDesign: DraftDesign): Mono<Long>
     }

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -146,7 +146,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<List<GetMyDraftDesigns.Response>>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 조회 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
@@ -177,7 +177,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<List<GetMyDraftDesigns.Response>>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 조회 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService.getMyDraftDesigns(WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
@@ -214,7 +214,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<GetMyDraftDesign.Response>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 조회 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService
                             .getMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
@@ -240,7 +240,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<GetMyDraftDesign.Response>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 조회 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService.getMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }
@@ -338,7 +338,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<DeleteDraftDesign.Response>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 삭제 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService
                             .deleteMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
@@ -360,7 +360,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
                     .expectBody<TestResponse<DeleteDraftDesign.Response>>()
                     .returnResult()
 
-                it("service 를 통해 생성 요청해야 함") {
+                it("service 를 통해 삭제 요청해야 함") {
                     verify(exactly = 1) {
                         mockDraftDesignService.deleteMyDraftDesign(1, WebTestClientHelper.AUTHORIZED_KNITTER_ID)
                     }

--- a/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
@@ -88,7 +88,7 @@ class DesignServiceTest : BehaviorSpec() {
                 val draftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
 
                 every {
-                    draftDesignRepository.findByIdAndKnitterId(any(), any())
+                    draftDesignRepository.getDraftDesign(any(), any())
                 } returns Mono.just(draftDesign)
 
                 every {
@@ -103,7 +103,7 @@ class DesignServiceTest : BehaviorSpec() {
 
                 Then("유저가 해당 임시저장 내역을 가지고 있는지 확인해야 한다") {
                     verify(exactly = 1) {
-                        draftDesignRepository.findByIdAndKnitterId(
+                        draftDesignRepository.getDraftDesign(
                             id = 1,
                             knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
                         )

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -30,14 +30,14 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
             When("작성 중이던 도안리스트를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(any())
+                    mockDraftDesignRepository.findDraftDesignsToCreate(any())
                 } returns Flux.fromIterable(listOf(mockDraftDesign))
 
                 val result = service.getMyDraftDesigns(1).collectList().block()
                 Then("작성 중이던 도안 목록을 조회해와야 한다") {
                     verify(exactly = 1) {
                         mockDraftDesignRepository
-                            .findDraftDesignsToCreateByKnitterId(1)
+                            .findDraftDesignsToCreate(1)
                     }
                 }
                 Then("작성 중이던 도안 리스트가 반환되어야 한다") {
@@ -47,13 +47,13 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
             When("작성 중이던 도안 상세를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                    mockDraftDesignRepository.getDraftDesign(any(), any())
                 } returns Mono.just(mockDraftDesign)
 
                 val result = service.getMyDraftDesign(1, 1).block()
                 Then("작성 중이던 도안을 조회해와야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
                 Then("작성 중이던 도안 상세가 반환되어야 한다") {
@@ -64,7 +64,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
             When("작성 중이던 도안을 삭제 요청하면") {
                 every {
                     mockDraftDesignRepository
-                        .findByIdAndKnitterId(any(), any())
+                        .getDraftDesign(any(), any())
                 } returns Mono.just(mockDraftDesign)
 
                 every {
@@ -75,7 +75,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
                 Then("작성 중이던 도안을 조회해야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
                 Then("작성 중이던 도안을 삭제해야 한다") {
@@ -92,13 +92,13 @@ class DraftDesignServiceTest : BehaviorSpec() {
         Given("내가 작성 중이던 도안이 존재하지 않고") {
             When("작성 중이던 도안리스트를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(any())
+                    mockDraftDesignRepository.findDraftDesignsToCreate(any())
                 } returns Flux.empty()
 
                 val result = service.getMyDraftDesigns(1).collectList().block()
                 Then("작성 중이던 도안 목록을 조회해와야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(1)
+                        mockDraftDesignRepository.findDraftDesignsToCreate(1)
                     }
                 }
                 Then("빈 리스트가 반환되어야 한다") {
@@ -108,14 +108,14 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
             When("작성 중이던 도안 상세를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                    mockDraftDesignRepository.getDraftDesign(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
 
                 val result = service.deleteMyDraftDesign(1, 1).test()
 
                 Then("작성 중이던 도안을 조회해와야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
                 Then("NotFoundEntity exception 이 발생해야 한다") {
@@ -125,14 +125,14 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
             When("작성 중이던 도안을 삭제 요청하면") {
                 every {
-                    mockDraftDesignRepository.findByIdAndKnitterId(any(), any())
+                    mockDraftDesignRepository.getDraftDesign(any(), any())
                 } returns Mono.error(NotFoundEntity(DraftDesign::class.java))
 
                 val result = service.deleteMyDraftDesign(1, 1).test()
 
                 Then("작성 중이던 도안을 조회해와야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
 
@@ -199,7 +199,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
                 every {
                     mockDraftDesignRepository
-                        .findByIdAndKnitterId(any(), any())
+                        .getDraftDesign(any(), any())
                 } returns Mono.just(beforeDraftDesign)
 
                 every {
@@ -209,7 +209,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 val result = service.saveDraft(data).block()
                 Then("기존 임시저장 내역을 조회해야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
                 Then("기존 임시저장 내역을 수정하여 저장해야 한다") {
@@ -293,7 +293,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
                 every {
                     mockDraftDesignRepository
-                        .findByIdAndKnitterId(any(), any())
+                        .getDraftDesign(any(), any())
                 } returns Mono.just(beforeDraftDesign)
 
                 every {
@@ -308,7 +308,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
                 Then("기존 임시저장 내역을 조회해야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDraftDesignRepository.getDraftDesign(1, 1)
                     }
                 }
                 Then("기존 임시저장 내역을 수정하여 저장해야 한다") {

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -30,14 +30,14 @@ class DraftDesignServiceTest : BehaviorSpec() {
 
             When("작성 중이던 도안리스트를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
+                    mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(any())
                 } returns Flux.fromIterable(listOf(mockDraftDesign))
 
                 val result = service.getMyDraftDesigns(1).collectList().block()
                 Then("작성 중이던 도안 목록을 조회해와야 한다") {
                     verify(exactly = 1) {
                         mockDraftDesignRepository
-                            .findNewDraftDesignsByKnitterId(1)
+                            .findDraftDesignsToCreateByKnitterId(1)
                     }
                 }
                 Then("작성 중이던 도안 리스트가 반환되어야 한다") {
@@ -92,13 +92,13 @@ class DraftDesignServiceTest : BehaviorSpec() {
         Given("내가 작성 중이던 도안이 존재하지 않고") {
             When("작성 중이던 도안리스트를 요청하면") {
                 every {
-                    mockDraftDesignRepository.findNewDraftDesignsByKnitterId(any())
+                    mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(any())
                 } returns Flux.empty()
 
                 val result = service.getMyDraftDesigns(1).collectList().block()
                 Then("작성 중이던 도안 목록을 조회해와야 한다") {
                     verify(exactly = 1) {
-                        mockDraftDesignRepository.findNewDraftDesignsByKnitterId(1)
+                        mockDraftDesignRepository.findDraftDesignsToCreateByKnitterId(1)
                     }
                 }
                 Then("빈 리스트가 반환되어야 한다") {

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -325,5 +325,34 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 }
             }
         }
+
+        Given("수정 중인 내역이 있는 도안이 존재하고") {
+            val draftDesignId = 1L
+            val designId = 2L
+            val knitterId = 3L
+            val mockDraftDesign = MockFactory.create(
+                MockData.DraftDesign(
+                    id = draftDesignId,
+                    designId = designId,
+                    knitterId = knitterId,
+                )
+            )
+            When("수정 내역 상세를 조회하면") {
+                every {
+                    mockDraftDesignRepository.getDraftDesignToUpdate(any(), any())
+                } returns Mono.just(mockDraftDesign)
+
+                val result = service.getMyDraftDesignToUpdate(designId, knitterId).block()
+                Then("수정 중이던 도안 상세를 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        mockDraftDesignRepository
+                            .getDraftDesignToUpdate(designId = 2, knitterId = 3)
+                    }
+                }
+                Then("수정 중이던 내용이 반환되어야 한다") {
+                    result shouldBe mockDraftDesign
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## PR 제안 사유
- 도안 수정 페이지 진입 전 수정중이던 내역이 있는지 확인할 수 있도록 수정 중이던 내역 조회할 수 있는 API를 구현합니다.
- 하면서 보이는 .. 이상한 것들도 고쳐줍니다 ㅎㅎ 
- 자세한 API 스펙은 [포스트맨](https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-af042e16-8cba-4be2-913a-d8b7bcc6158c)에서 확인 고고 합니다.

Resolves #1z5f2xx

## 주요 변경 기록
- repository 메서드 이름들을 service에 알맞게 변경해줍니다.
- 오타들 수정
- 도안 수정 중인 내역 조회 API 구현 
- 임시저장 내역 상세 API response 수정
  - nullable한 값이 아니므로 non-null로 변경
 - path variable 구체적으로 변경 