### PR TITLE
feat: move /design api to /designs

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/filter/auth/AuthorizationFilter.kt
@@ -10,7 +10,6 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 import com.kroffle.knitting.controller.router.auth.CertRouter.Companion.PUBLIC_PATHS as CertRouterPublicPaths
 import com.kroffle.knitting.controller.router.auth.LogInRouter.Companion.PUBLIC_PATHS as LogInRouterPublicPaths
-import com.kroffle.knitting.controller.router.design.DesignRouter.Companion.PUBLIC_PATHS as DesignRouterPublicPaths
 import com.kroffle.knitting.controller.router.design.DesignsRouter.Companion.PUBLIC_PATHS as DesignsRouterPublicPaths
 import com.kroffle.knitting.controller.router.knitter.MyselfRouter.Companion.PUBLIC_PATHS as MyselfRouterPublicPaths
 import com.kroffle.knitting.controller.router.product.ProductRouter.Companion.PUBLIC_PATHS as ProductRouterPublicPaths
@@ -58,7 +57,6 @@ class AuthorizationFilter(private val tokenDecoder: TokenDecoder) : WebFilter {
             LogInRouterPublicPaths +
                 CertRouterPublicPaths +
                 MyselfRouterPublicPaths +
-                DesignRouterPublicPaths +
                 DesignsRouterPublicPaths +
                 ProductRouterPublicPaths +
                 ACTUATOR_PATHS

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignRouter.kt
@@ -8,6 +8,7 @@ import org.springframework.web.reactive.function.server.RequestPredicates.path
 import org.springframework.web.reactive.function.server.RouterFunctions.nest
 import org.springframework.web.reactive.function.server.router
 
+@Deprecated("remove after client doesn't use")
 @Configuration
 class DesignRouter(
     private val designHandler: DesignHandler,
@@ -30,6 +31,5 @@ class DesignRouter(
         private const val CREATE_DESIGN_PATH = ""
         private const val SAVE_DRAFT_PATH = "/draft"
         private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
-        val PUBLIC_PATHS = listOf<String>()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -9,7 +9,10 @@ import org.springframework.web.reactive.function.server.RouterFunctions.nest
 import org.springframework.web.reactive.function.server.router
 
 @Configuration
-class DesignsRouter(private val designHandler: DesignHandler, private val draftDesignHandler: DraftDesignHandler) {
+class DesignsRouter(
+    private val designHandler: DesignHandler,
+    private val draftDesignHandler: DraftDesignHandler,
+) {
     @Bean
     fun designsRouterFunction() = nest(
         path(ROOT_PATH),
@@ -19,6 +22,9 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
                 GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
                 GET(GET_MY_DRAFT_DESIGN_PATH, draftDesignHandler::getMyDraftDesign),
                 GET(GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH, draftDesignHandler::getMyDraftDesignToUpdate),
+                POST(CREATE_DESIGN_PATH, designHandler::createDesign),
+                POST(SAVE_DRAFT_PATH, draftDesignHandler::saveDraft),
+                DELETE(DELETE_MY_DRAFT_DESIGN_PATH, draftDesignHandler::deleteMyDraftDesign),
             )
         }
     )
@@ -29,6 +35,9 @@ class DesignsRouter(private val designHandler: DesignHandler, private val draftD
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
         private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
         private const val GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH = "/{designId}/draft/mine"
+        private const val CREATE_DESIGN_PATH = ""
+        private const val SAVE_DRAFT_PATH = "/draft"
+        private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandlerTest.kt
@@ -3,7 +3,7 @@ package com.kroffle.knitting.controller.handler.design
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
-import com.kroffle.knitting.controller.router.design.DesignRouter
+import com.kroffle.knitting.controller.router.design.DesignsRouter
 import com.kroffle.knitting.domain.design.entity.Design
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
@@ -28,18 +28,18 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Mono
 
-@DisplayName("DesignRouter Test")
+@DisplayName("DesignHandler Test")
 class DesignHandlerTest : DescribeSpec() {
     init {
         val service = mockk<DesignService>()
-        val router = DesignRouter(DesignHandler(service), mockk())
+        val router = DesignsRouter(DesignHandler(service), mockk())
         val webClient = WebTestClientHelper
-            .createWebTestClient(router.designRouterFunction())
+            .createWebTestClient(router.designsRouterFunction())
 
         val exchangeRequest = fun (requestBody: String?): WebTestClient.ResponseSpec {
             val client = webClient
                 .post()
-                .uri("/design")
+                .uri("/designs")
                 .addDefaultRequestHeader()
             return if (requestBody == null) {
                 client

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -7,7 +7,6 @@ import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
-import com.kroffle.knitting.controller.router.design.DesignRouter
 import com.kroffle.knitting.controller.router.design.DesignsRouter
 import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
 import com.kroffle.knitting.helper.MockData
@@ -37,19 +36,16 @@ class DraftDesignHandlerTest : DescribeSpec() {
     init {
         val mockDraftDesignService = mockk<DraftDesignService>()
         val designsRouter = DesignsRouter(mockk(), DraftDesignHandler(mockDraftDesignService))
-        val designRouter = DesignRouter(mockk(), DraftDesignHandler(mockDraftDesignService))
         val designsWebclient = WebTestClientHelper
             .createWebTestClient(designsRouter.designsRouterFunction())
-        val designWebclient = WebTestClientHelper
-            .createWebTestClient(designRouter.designRouterFunction())
 
         afterContainer { clearAllMocks() }
 
         describe("임시저장 저장 test") {
             val exchangeRequest = fun (requestBody: String): WebTestClient.ResponseSpec =
-                designWebclient
+                designsWebclient
                     .post()
-                    .uri("/design/draft")
+                    .uri("/designs/draft")
                     .addDefaultRequestHeader()
                     .bodyValue(requestBody)
                     .exchange()
@@ -99,9 +95,9 @@ class DraftDesignHandlerTest : DescribeSpec() {
             }
 
             context("request body 가 없는 경우") {
-                val response = designWebclient
+                val response = designsWebclient
                     .post()
-                    .uri("/design/draft")
+                    .uri("/designs/draft")
                     .addDefaultRequestHeader()
                     .exchange()
                     .expectBody<EmptyBodyException>()
@@ -323,9 +319,9 @@ class DraftDesignHandlerTest : DescribeSpec() {
 
         describe("임시저장 삭제 test") {
             val exchangeRequest = fun (): WebTestClient.ResponseSpec =
-                designWebclient
+                designsWebclient
                     .delete()
-                    .uri("/design/draft/mine/1")
+                    .uri("/designs/draft/mine/1")
                     .addDefaultRequestHeader()
                     .exchange()
 


### PR DESCRIPTION
## PR 제안 사유
- REST api convention 상 복수형태의 noun을 쓰는 것을 권장하고 있어서 컨벤션에 맞게 수정합니다.
- 아직 /design으로 시작하는 API를 제거하지는 않아서 동작에는 문제없겠지만 클라이언트에서 수정이 필요합니다.

Resolves #20dbt3k

## 주요 변경 기록
- /design API path 변경