### PR TITLE
refactor: Handler 레이어에 mapper object 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/CertHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/CertHandler.kt
@@ -12,7 +12,7 @@ class CertHandler(
     @Value("\${cert.secret}")
     private val certSecret: String,
 ) {
-    fun applyHttps(req: ServerRequest): Mono<ServerResponse> = ServerResponse.ok()
+    fun applyHttps(request: ServerRequest): Mono<ServerResponse> = ServerResponse.ok()
         .contentType(MediaType.TEXT_PLAIN)
         .bodyValue(certSecret)
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/GoogleLogInHandler.kt
@@ -14,12 +14,12 @@ import reactor.core.publisher.Mono
 
 @Component
 class GoogleLogInHandler(private val authService: AuthService) {
-    fun requestCode(req: ServerRequest): Mono<ServerResponse> {
+    fun requestCode(request: ServerRequest): Mono<ServerResponse> {
         return temporaryRedirect(authService.getAuthorizationUri()).build()
     }
 
-    fun authorized(req: ServerRequest): Mono<ServerResponse> {
-        val code = req.queryParam("code")
+    fun authorized(request: ServerRequest): Mono<ServerResponse> {
+        val code = request.queryParam("code")
         if (code.isEmpty || code.get().isBlank()) {
             ExceptionHelper.raiseException(NotFoundCode())
         }
@@ -30,8 +30,8 @@ class GoogleLogInHandler(private val authService: AuthService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun refreshToken(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun refreshToken(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
         val refreshToken = authService.refreshToken(knitterId)
         val response = GoogleLoginResponseMapper.toRefreshTokenResponse(refreshToken)
         return ResponseHelper.makeJsonResponse(response)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/mapper/GoogleLoginResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/auth/mapper/GoogleLoginResponseMapper.kt
@@ -1,0 +1,12 @@
+package com.kroffle.knitting.controller.handler.auth.mapper
+
+import com.kroffle.knitting.controller.handler.auth.dto.Authorized
+import com.kroffle.knitting.controller.handler.auth.dto.RefreshToken
+
+object GoogleLoginResponseMapper {
+    fun toAuthorizedResponse(token: String): Authorized.Response =
+        Authorized.Response(token)
+
+    fun toRefreshTokenResponse(token: String): RefreshToken.Response =
+        RefreshToken.Response(token)
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -18,12 +18,12 @@ import java.util.stream.Collectors.toList
 
 @Component
 class DesignHandler(private val service: DesignService) {
-    fun createDesign(req: ServerRequest): Mono<ServerResponse> {
-        val design: Mono<NewDesign.Request> = req
+    fun createDesign(request: ServerRequest): Mono<ServerResponse> {
+        val design: Mono<NewDesign.Request> = request
             .bodyToMono(NewDesign.Request::class.java)
             .onErrorResume { Mono.error(InvalidBodyException()) }
             .switchIfEmpty(Mono.error(EmptyBodyException()))
-        val knitterId = AuthHelper.getKnitterId(req)
+        val knitterId = AuthHelper.getKnitterId(request)
         return design
             .map { DesignRequestMapper.toCreateDesignData(it, knitterId) }
             .flatMap(service::create)
@@ -32,9 +32,9 @@ class DesignHandler(private val service: DesignService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyDesigns(req: ServerRequest): Mono<ServerResponse> {
-        val paging = PaginationHelper.getPagingFromRequest(req)
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun getMyDesigns(request: ServerRequest): Mono<ServerResponse> {
+        val paging = PaginationHelper.getPagingFromRequest(request)
+        val knitterId = AuthHelper.getKnitterId(request)
         return service
             .getMyDesign(DesignRequestMapper.toMyDesignFilter(paging, knitterId))
             .doOnError(ExceptionHelper::raiseException)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
@@ -1,0 +1,69 @@
+package com.kroffle.knitting.controller.handler.design.mapper
+
+import com.kroffle.knitting.controller.handler.design.dto.NewDesign
+import com.kroffle.knitting.domain.design.value.Gauge
+import com.kroffle.knitting.domain.design.value.Length
+import com.kroffle.knitting.domain.design.value.Pattern
+import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
+import com.kroffle.knitting.domain.value.Money
+import com.kroffle.knitting.usecase.design.dto.CreateDesignData
+import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+
+object DesignRequestMapper {
+    fun toCreateDesignData(data: NewDesign.Request, knitterId: Long): CreateDesignData =
+        with(data) {
+            CreateDesignData(
+                knitterId = knitterId,
+                name = name,
+                designType = designType,
+                patternType = patternType,
+                gauge = Gauge(
+                    stitches = stitches,
+                    rows = rows,
+                ),
+                size = Size(
+                    totalLength = Length(
+                        value = size.totalLength,
+                        unit = size.sizeUnit,
+                    ),
+                    sleeveLength = Length(
+                        value = size.sleeveLength,
+                        unit = size.sizeUnit,
+                    ),
+                    shoulderWidth = Length(
+                        value = size.shoulderWidth,
+                        unit = size.sizeUnit,
+                    ),
+                    bottomWidth = Length(
+                        value = size.bottomWidth,
+                        unit = size.sizeUnit,
+                    ),
+                    armholeDepth = Length(
+                        value = size.armholeDepth,
+                        unit = size.sizeUnit,
+                    ),
+                ),
+                needle = needle,
+                yarn = yarn,
+                extra = extra,
+                price = Money(price),
+                pattern = Pattern(pattern),
+                description = description,
+                targetLevel = targetLevel,
+                coverImageUrl = coverImageUrl,
+                techniques = techniques.map { technique -> Technique(technique) },
+                draftId = draftId,
+            )
+        }
+
+    fun toMyDesignFilter(paging: Paging, knitterId: Long) =
+        MyDesignFilter(
+            knitterId,
+            paging,
+            Sort("id", SortDirection.DESC),
+        )
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignResponseMapper.kt
@@ -1,0 +1,24 @@
+package com.kroffle.knitting.controller.handler.design.mapper
+
+import com.kroffle.knitting.controller.handler.design.dto.MyDesign
+import com.kroffle.knitting.controller.handler.design.dto.NewDesign
+import com.kroffle.knitting.domain.design.entity.Design
+
+object DesignResponseMapper {
+    fun toNewDesignResponse(design: Design): NewDesign.Response =
+        with(design) {
+            NewDesign.Response(id = id!!)
+        }
+
+    fun toMyDesignResponse(design: Design): MyDesign.Response =
+        with(design) {
+            MyDesign.Response(
+                id = id!!,
+                name = name,
+                yarn = yarn,
+                coverImageUrl = coverImageUrl,
+                tags = listOf(designType.tag, patternType.tag),
+                createdAt = createdAt!!,
+            )
+        }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -17,12 +17,12 @@ import java.util.stream.Collectors
 
 @Component
 class DraftDesignHandler(private val service: DraftDesignService) {
-    fun saveDraft(req: ServerRequest): Mono<ServerResponse> {
-        val body: Mono<SaveDraftDesign.Request> = req
+    fun saveDraft(request: ServerRequest): Mono<ServerResponse> {
+        val body: Mono<SaveDraftDesign.Request> = request
             .bodyToMono(SaveDraftDesign.Request::class.java)
             .onErrorResume { Mono.error(InvalidBodyException()) }
             .switchIfEmpty(Mono.error(EmptyBodyException()))
-        val knitterId = AuthHelper.getKnitterId(req)
+        val knitterId = AuthHelper.getKnitterId(request)
         return body
             .map { DraftDesignRequestMapper.toSaveDraftDesignData(it, knitterId) }
             .flatMap(service::saveDraft)
@@ -31,8 +31,8 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyDraftDesigns(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun getMyDraftDesigns(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
         return service
             .getMyDraftDesigns(knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -41,9 +41,9 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val draftDesignId = req.pathVariable("draftDesignId").toLong()
+    fun getMyDraftDesign(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val draftDesignId = request.pathVariable("draftDesignId").toLong()
         return service
             .getMyDraftDesign(draftDesignId, knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -51,9 +51,9 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyDraftDesignToUpdate(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val designId = req.pathVariable("designId").toLong()
+    fun getMyDraftDesignToUpdate(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val designId = request.pathVariable("designId").toLong()
         return service
             .getMyDraftDesignToUpdate(designId = designId, knitterId = knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -61,9 +61,9 @@ class DraftDesignHandler(private val service: DraftDesignService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun deleteMyDraftDesign(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val draftDesignId = req.pathVariable("draftDesignId").toLong()
+    fun deleteMyDraftDesign(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val draftDesignId = request.pathVariable("draftDesignId").toLong()
         return service
             .deleteMyDraftDesign(draftDesignId, knitterId)
             .doOnError(ExceptionHelper::raiseException)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/mapper/DraftDesignRequestMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/mapper/DraftDesignRequestMapper.kt
@@ -1,0 +1,19 @@
+package com.kroffle.knitting.controller.handler.draftdesign.mapper
+
+import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
+import com.kroffle.knitting.usecase.draftdesign.dto.SaveDraftDesignData
+
+object DraftDesignRequestMapper {
+    fun toSaveDraftDesignData(
+        data: SaveDraftDesign.Request,
+        knitterId: Long,
+    ): SaveDraftDesignData =
+        with(data) {
+            SaveDraftDesignData(
+                id = id,
+                knitterId = knitterId,
+                designId = designId,
+                value = value,
+            )
+        }
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/mapper/DraftDesignResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/mapper/DraftDesignResponseMapper.kt
@@ -1,0 +1,45 @@
+package com.kroffle.knitting.controller.handler.draftdesign.mapper
+
+import com.kroffle.knitting.controller.handler.draftdesign.dto.DeleteDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesign
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesignToUpdate
+import com.kroffle.knitting.controller.handler.draftdesign.dto.GetMyDraftDesigns
+import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
+import com.kroffle.knitting.domain.draftdesign.entity.DraftDesign
+
+object DraftDesignResponseMapper {
+    fun toSaveDraftDesignResponse(draftDesign: DraftDesign): SaveDraftDesign.Response =
+        with(draftDesign) {
+            SaveDraftDesign.Response(id = id!!)
+        }
+
+    fun toGetMyDraftDesignsResponse(draftDesign: DraftDesign): GetMyDraftDesigns.Response =
+        with(draftDesign) {
+            GetMyDraftDesigns.Response(
+                id = id!!,
+                name = name,
+                updatedAt = updatedAt!!,
+            )
+        }
+
+    fun toGetMyDraftDesignResponse(draftDesign: DraftDesign): GetMyDraftDesign.Response =
+        with(draftDesign) {
+            GetMyDraftDesign.Response(
+                id = id!!,
+                value = value,
+                updatedAt = updatedAt!!,
+            )
+        }
+
+    fun toGetMyDraftDesignToUpdateResponse(draftDesign: DraftDesign): GetMyDraftDesignToUpdate.Response =
+        with(draftDesign) {
+            GetMyDraftDesignToUpdate.Response(
+                id = id!!,
+                value = value,
+                updatedAt = updatedAt!!,
+            )
+        }
+
+    fun toDeleteDraftDesignResponse(deletedId: Long): DeleteDraftDesign.Response =
+        DeleteDraftDesign.Response(id = deletedId)
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/pagination/PaginationHelper.kt
@@ -22,9 +22,9 @@ class PaginationHelper {
             else Integer.parseInt(count)
         }
 
-        fun getPagingFromRequest(req: ServerRequest): Paging {
+        fun getPagingFromRequest(request: ServerRequest): Paging {
             try {
-                return Paging(after = getAfter(req), count = getCount(req))
+                return Paging(after = getAfter(request), count = getCount(request))
             } catch (error: IllegalArgumentException) {
                 throw InvalidPagingParameter()
             }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/MyselfHandler.kt
@@ -16,8 +16,8 @@ class MyselfHandler(
     private val knitterService: KnitterService,
     private val productSummaryService: ProductSummaryService,
 ) {
-    fun getMyProfile(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun getMyProfile(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
         return knitterService
             .getKnitter(knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -25,8 +25,8 @@ class MyselfHandler(
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMySalesSummary(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun getMySalesSummary(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
         return productSummaryService
             .countProductOnList(knitterId)
             .doOnError(ExceptionHelper::raiseException)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/mapper/MyselfResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/mapper/MyselfResponseMapper.kt
@@ -1,0 +1,22 @@
+package com.kroffle.knitting.controller.handler.knitter.mapper
+
+import com.kroffle.knitting.controller.handler.knitter.dto.MyProfile
+import com.kroffle.knitting.controller.handler.knitter.dto.SalesSummary
+import com.kroffle.knitting.domain.knitter.entity.Knitter
+
+object MyselfResponseMapper {
+    fun toMyProfileResponse(knitter: Knitter): MyProfile.Response =
+        with(knitter) {
+            MyProfile.Response(
+                email = email,
+                name = name,
+                profileImageUrl = profileImageUrl,
+            )
+        }
+
+    fun toSalesSummaryResponse(numberOfProductsOnSales: Long): SalesSummary.Response =
+        SalesSummary.Response(
+            numberOfProductsOnSales = numberOfProductsOnSales,
+            numberOfProductsSold = 0,
+        )
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -20,9 +20,9 @@ import java.util.stream.Collectors.toList
 
 @Component
 class ProductHandler(private val productService: ProductService) {
-    fun editProductPackage(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val bodyMono: Mono<EditProductPackage.Request> = req
+    fun editProductPackage(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val bodyMono: Mono<EditProductPackage.Request> = request
             .bodyToMono(EditProductPackage.Request::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
@@ -36,9 +36,9 @@ class ProductHandler(private val productService: ProductService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun editProductContent(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val bodyMono: Mono<EditProductContent.Request> = req
+    fun editProductContent(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val bodyMono: Mono<EditProductContent.Request> = request
             .bodyToMono(EditProductContent.Request::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
@@ -52,9 +52,9 @@ class ProductHandler(private val productService: ProductService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun registerProduct(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val bodyMono: Mono<RegisterProduct.Request> = req
+    fun registerProduct(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val bodyMono: Mono<RegisterProduct.Request> = request
             .bodyToMono(RegisterProduct.Request::class.java)
             .switchIfEmpty(Mono.error(EmptyBodyException()))
 
@@ -68,9 +68,9 @@ class ProductHandler(private val productService: ProductService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyProduct(req: ServerRequest): Mono<ServerResponse> {
-        val knitterId = AuthHelper.getKnitterId(req)
-        val productId = req.pathVariable("productId").toLong()
+    fun getMyProduct(request: ServerRequest): Mono<ServerResponse> {
+        val knitterId = AuthHelper.getKnitterId(request)
+        val productId = request.pathVariable("productId").toLong()
 
         return productService
             .get(ProductRequestMapper.toGetMyProductData(productId, knitterId))
@@ -79,9 +79,9 @@ class ProductHandler(private val productService: ProductService) {
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 
-    fun getMyProducts(req: ServerRequest): Mono<ServerResponse> {
-        val paging = PaginationHelper.getPagingFromRequest(req)
-        val knitterId = AuthHelper.getKnitterId(req)
+    fun getMyProducts(request: ServerRequest): Mono<ServerResponse> {
+        val paging = PaginationHelper.getPagingFromRequest(request)
+        val knitterId = AuthHelper.getKnitterId(request)
 
         return productService
             .get(ProductRequestMapper.toGetMyProductsData(paging, knitterId))

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/mapper/ProductRequestMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/mapper/ProductRequestMapper.kt
@@ -1,0 +1,64 @@
+package com.kroffle.knitting.controller.handler.product.mapper
+
+import com.kroffle.knitting.controller.handler.product.dto.EditProductContent
+import com.kroffle.knitting.controller.handler.product.dto.EditProductPackage
+import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
+import com.kroffle.knitting.domain.product.value.ProductItem
+import com.kroffle.knitting.domain.product.value.ProductTag
+import com.kroffle.knitting.domain.value.Money
+import com.kroffle.knitting.usecase.helper.pagination.type.Paging
+import com.kroffle.knitting.usecase.helper.pagination.type.Sort
+import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
+import com.kroffle.knitting.usecase.product.dto.EditProductContentData
+import com.kroffle.knitting.usecase.product.dto.EditProductPackageData
+import com.kroffle.knitting.usecase.product.dto.GetMyProductData
+import com.kroffle.knitting.usecase.product.dto.GetMyProductsData
+import com.kroffle.knitting.usecase.product.dto.RegisterProductData
+
+object ProductRequestMapper {
+    fun toEditProductPackageData(data: EditProductPackage.Request, knitterId: Long): EditProductPackageData =
+        with(data) {
+            EditProductPackageData(
+                id = id,
+                knitterId = knitterId,
+                name = name,
+                fullPrice = Money(fullPrice),
+                discountPrice = Money(discountPrice),
+                representativeImageUrl = representativeImageUrl,
+                specifiedSalesStartDate = specifiedSalesStartDate,
+                specifiedSalesEndDate = specifiedSalesEndDate,
+                tags = tags.map { ProductTag(it) },
+                items = designIds.map { ProductItem.create(it, ProductItem.Type.DESIGN) },
+            )
+        }
+
+    fun toEditProductContentData(data: EditProductContent.Request, knitterId: Long): EditProductContentData =
+        with(data) {
+            EditProductContentData(
+                id = id,
+                knitterId = knitterId,
+                content = content,
+            )
+        }
+
+    fun toRegisterProductData(data: RegisterProduct.Request, knitterId: Long): RegisterProductData =
+        with(data) {
+            RegisterProductData(
+                id = id,
+                knitterId = knitterId,
+            )
+        }
+
+    fun toGetMyProductData(productId: Long, knitterId: Long) =
+        GetMyProductData(
+            id = productId,
+            knitterId = knitterId,
+        )
+
+    fun toGetMyProductsData(paging: Paging, knitterId: Long) =
+        GetMyProductsData(
+            knitterId = knitterId,
+            paging = paging,
+            sort = Sort("id", SortDirection.DESC),
+        )
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/mapper/ProductResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/mapper/ProductResponseMapper.kt
@@ -1,0 +1,66 @@
+package com.kroffle.knitting.controller.handler.product.mapper
+
+import com.kroffle.knitting.controller.handler.product.dto.EditProductContent
+import com.kroffle.knitting.controller.handler.product.dto.EditProductPackage
+import com.kroffle.knitting.controller.handler.product.dto.GetMyProduct
+import com.kroffle.knitting.controller.handler.product.dto.GetMyProducts
+import com.kroffle.knitting.controller.handler.product.dto.RegisterProduct
+import com.kroffle.knitting.domain.product.entity.Product
+
+object ProductResponseMapper {
+    fun toEditProductPackageResponse(product: Product): EditProductPackage.Response =
+        with(product) {
+            EditProductPackage.Response(
+                id = id!!,
+            )
+        }
+
+    fun toEditProductContentResponse(product: Product): EditProductContent.Response =
+        with(product) {
+            EditProductContent.Response(
+                id = id!!,
+            )
+        }
+
+    fun toRegisterProductResponse(product: Product): RegisterProduct.Response =
+        with(product) {
+            RegisterProduct.Response(
+                id = id!!,
+            )
+        }
+
+    fun toGetMyProductResponse(product: Product): GetMyProduct.Response =
+        with(product) {
+            GetMyProduct.Response(
+                id = id!!,
+                name = name,
+                fullPrice = fullPrice.value,
+                discountPrice = discountPrice.value,
+                representativeImageUrl = representativeImageUrl,
+                specifiedSalesStartDate = specifiedSalesStartDate,
+                specifiedSalesEndDate = specifiedSalesEndDate,
+                tags = tags.map { it.name },
+                content = content,
+                inputStatus = inputStatus,
+                itemIds = items.map { it.itemId },
+                createdAt = createdAt!!,
+                updatedAt = updatedAt!!,
+            )
+        }
+
+    fun toGetMyProductsResponse(product: Product): GetMyProducts.Response =
+        with(product) {
+            GetMyProducts.Response(
+                id = id!!,
+                name = name,
+                fullPrice = fullPrice.value,
+                discountPrice = discountPrice.value,
+                representativeImageUrl = representativeImageUrl,
+                specifiedSalesStartDate = specifiedSalesStartDate,
+                specifiedSalesEndDate = specifiedSalesEndDate,
+                tags = tags.map { it.name },
+                inputStatus = inputStatus,
+                updatedAt = updatedAt,
+            )
+        }
+}


### PR DESCRIPTION
## PR 제안 사유
- mapping 로직에 의해서 handler 동작을 파악하는데 방해가 되기 때문에 mapping 하는 로직을 별도의 object로 분리합니다.

Resolves #1vk3n75

## 주요 변경 기록
- handler 레이어에 있는 mapping 코드 Mapper object로 이동
