### PR TITLE
feat: 도안 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -1,10 +1,12 @@
 package com.kroffle.knitting.controller.handler.design
 
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
+import com.kroffle.knitting.controller.handler.design.dto.UpdateDesign
 import com.kroffle.knitting.controller.handler.design.mapper.DesignRequestMapper
 import com.kroffle.knitting.controller.handler.design.mapper.DesignResponseMapper
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.getLongPathVariable
 import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.safetyBodyToMono
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
@@ -25,6 +27,18 @@ class DesignHandler(private val service: DesignService) {
             .flatMap(service::create)
             .doOnError(ExceptionHelper::raiseException)
             .map(DesignResponseMapper::toNewDesignResponse)
+            .flatMap(ResponseHelper::makeJsonResponse)
+    }
+
+    fun updateDesign(request: ServerRequest): Mono<ServerResponse> {
+        val design = request.safetyBodyToMono(UpdateDesign.Request::class.java)
+        val designId = request.getLongPathVariable("designId")
+        val knitterId = AuthHelper.getKnitterId(request)
+        return design
+            .map { DesignRequestMapper.toUpdateDesignData(it, designId, knitterId) }
+            .flatMap(service::update)
+            .doOnError(ExceptionHelper::raiseException)
+            .map(DesignResponseMapper::toUpdateDesignResponse)
             .flatMap(ResponseHelper::makeJsonResponse)
     }
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/DesignHandler.kt
@@ -3,10 +3,9 @@ package com.kroffle.knitting.controller.handler.design
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
 import com.kroffle.knitting.controller.handler.design.mapper.DesignRequestMapper
 import com.kroffle.knitting.controller.handler.design.mapper.DesignResponseMapper
-import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
-import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.safetyBodyToMono
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.usecase.design.DesignService
@@ -19,10 +18,7 @@ import java.util.stream.Collectors.toList
 @Component
 class DesignHandler(private val service: DesignService) {
     fun createDesign(request: ServerRequest): Mono<ServerResponse> {
-        val design: Mono<NewDesign.Request> = request
-            .bodyToMono(NewDesign.Request::class.java)
-            .onErrorResume { Mono.error(InvalidBodyException()) }
-            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val design = request.safetyBodyToMono(NewDesign.Request::class.java)
         val knitterId = AuthHelper.getKnitterId(request)
         return design
             .map { DesignRequestMapper.toCreateDesignData(it, knitterId) }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
@@ -3,7 +3,6 @@ package com.kroffle.knitting.controller.handler.design.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import com.kroffle.knitting.domain.design.entity.Design
-import com.kroffle.knitting.domain.design.value.Length
 
 object NewDesign {
     data class Request(
@@ -14,7 +13,7 @@ object NewDesign {
         val patternType: Design.PatternType,
         val stitches: Double,
         val rows: Double,
-        val size: NewDesignSize,
+        val size: SizeDto,
         val needle: String,
         val yarn: String,
         val extra: String?,
@@ -28,22 +27,7 @@ object NewDesign {
         val techniques: List<String>,
         @JsonProperty("draft_id")
         val draftId: Long?,
-    ) {
-        data class NewDesignSize(
-            @JsonProperty("size_unit")
-            val sizeUnit: Length.Unit = Length.Unit.Cm,
-            @JsonProperty("total_length")
-            val totalLength: Double,
-            @JsonProperty("sleeve_length")
-            val sleeveLength: Double,
-            @JsonProperty("shoulder_width")
-            val shoulderWidth: Double,
-            @JsonProperty("bottom_width")
-            val bottomWidth: Double,
-            @JsonProperty("armhole_depth")
-            val armholeDepth: Double,
-        )
-    }
+    )
 
     data class Response(
         val id: Long,

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SizeDto.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SizeDto.kt
@@ -1,0 +1,19 @@
+package com.kroffle.knitting.controller.handler.design.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.domain.design.value.Length
+
+data class SizeDto(
+    @JsonProperty("size_unit")
+    val sizeUnit: Length.Unit = Length.Unit.Cm,
+    @JsonProperty("total_length")
+    val totalLength: Double,
+    @JsonProperty("sleeve_length")
+    val sleeveLength: Double,
+    @JsonProperty("shoulder_width")
+    val shoulderWidth: Double,
+    @JsonProperty("bottom_width")
+    val bottomWidth: Double,
+    @JsonProperty("armhole_depth")
+    val armholeDepth: Double,
+)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/UpdateDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/UpdateDesign.kt
@@ -1,0 +1,31 @@
+package com.kroffle.knitting.controller.handler.design.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
+import com.kroffle.knitting.domain.design.entity.Design
+
+object UpdateDesign {
+    data class Request(
+        @JsonProperty("design_type")
+        val designType: Design.DesignType,
+        @JsonProperty("pattern_type")
+        val patternType: Design.PatternType,
+        val stitches: Double,
+        val rows: Double,
+        val size: SizeDto,
+        val needle: String,
+        val yarn: String,
+        val extra: String?,
+        val pattern: String,
+        val description: String,
+        @JsonProperty("target_level")
+        val targetLevel: Design.LevelType,
+        val techniques: List<String>,
+        @JsonProperty("draft_id")
+        val draftId: Long?,
+    )
+
+    data class Response(
+        val id: Long,
+    ) : ObjectPayload
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
@@ -1,6 +1,7 @@
 package com.kroffle.knitting.controller.handler.design.mapper
 
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
+import com.kroffle.knitting.controller.handler.design.dto.SizeDto
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
@@ -25,28 +26,7 @@ object DesignRequestMapper {
                     stitches = stitches,
                     rows = rows,
                 ),
-                size = Size(
-                    totalLength = Length(
-                        value = size.totalLength,
-                        unit = size.sizeUnit,
-                    ),
-                    sleeveLength = Length(
-                        value = size.sleeveLength,
-                        unit = size.sizeUnit,
-                    ),
-                    shoulderWidth = Length(
-                        value = size.shoulderWidth,
-                        unit = size.sizeUnit,
-                    ),
-                    bottomWidth = Length(
-                        value = size.bottomWidth,
-                        unit = size.sizeUnit,
-                    ),
-                    armholeDepth = Length(
-                        value = size.armholeDepth,
-                        unit = size.sizeUnit,
-                    ),
-                ),
+                size = toDomainFromDto(size),
                 needle = needle,
                 yarn = yarn,
                 extra = extra,
@@ -66,4 +46,15 @@ object DesignRequestMapper {
             paging,
             Sort("id", SortDirection.DESC),
         )
+
+    private fun toDomainFromDto(size: SizeDto): Size =
+        with(size) {
+            Size(
+                totalLength = Length(value = totalLength, unit = sizeUnit),
+                sleeveLength = Length(value = sleeveLength, unit = sizeUnit),
+                shoulderWidth = Length(value = shoulderWidth, unit = sizeUnit),
+                bottomWidth = Length(value = bottomWidth, unit = sizeUnit),
+                armholeDepth = Length(value = armholeDepth, unit = sizeUnit),
+            )
+        }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignRequestMapper.kt
@@ -2,6 +2,7 @@ package com.kroffle.knitting.controller.handler.design.mapper
 
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
 import com.kroffle.knitting.controller.handler.design.dto.SizeDto
+import com.kroffle.knitting.controller.handler.design.dto.UpdateDesign
 import com.kroffle.knitting.domain.design.value.Gauge
 import com.kroffle.knitting.domain.design.value.Length
 import com.kroffle.knitting.domain.design.value.Pattern
@@ -10,6 +11,7 @@ import com.kroffle.knitting.domain.design.value.Technique
 import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.MyDesignFilter
+import com.kroffle.knitting.usecase.design.dto.UpdateDesignData
 import com.kroffle.knitting.usecase.helper.pagination.type.Paging
 import com.kroffle.knitting.usecase.helper.pagination.type.Sort
 import com.kroffle.knitting.usecase.helper.pagination.type.SortDirection
@@ -36,6 +38,29 @@ object DesignRequestMapper {
                 targetLevel = targetLevel,
                 coverImageUrl = coverImageUrl,
                 techniques = techniques.map { technique -> Technique(technique) },
+                draftId = draftId,
+            )
+        }
+
+    fun toUpdateDesignData(data: UpdateDesign.Request, designId: Long, knitterId: Long): UpdateDesignData =
+        with(data) {
+            UpdateDesignData(
+                id = designId,
+                knitterId = knitterId,
+                designType = designType,
+                patternType = patternType,
+                gauge = Gauge(
+                    stitches = stitches,
+                    rows = rows,
+                ),
+                size = toDomainFromDto(size),
+                needle = needle,
+                yarn = yarn,
+                extra = extra,
+                pattern = Pattern(pattern),
+                description = description,
+                targetLevel = targetLevel,
+                techniques = techniques.map { Technique(it) },
                 draftId = draftId,
             )
         }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignResponseMapper.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/mapper/DesignResponseMapper.kt
@@ -2,12 +2,18 @@ package com.kroffle.knitting.controller.handler.design.mapper
 
 import com.kroffle.knitting.controller.handler.design.dto.MyDesign
 import com.kroffle.knitting.controller.handler.design.dto.NewDesign
+import com.kroffle.knitting.controller.handler.design.dto.UpdateDesign
 import com.kroffle.knitting.domain.design.entity.Design
 
 object DesignResponseMapper {
     fun toNewDesignResponse(design: Design): NewDesign.Response =
         with(design) {
             NewDesign.Response(id = id!!)
+        }
+
+    fun toUpdateDesignResponse(design: Design): UpdateDesign.Response =
+        with(design) {
+            UpdateDesign.Response(id = id!!)
         }
 
     fun toMyDesignResponse(design: Design): MyDesign.Response =

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandler.kt
@@ -3,10 +3,10 @@ package com.kroffle.knitting.controller.handler.draftdesign
 import com.kroffle.knitting.controller.handler.draftdesign.dto.SaveDraftDesign
 import com.kroffle.knitting.controller.handler.draftdesign.mapper.DraftDesignRequestMapper
 import com.kroffle.knitting.controller.handler.draftdesign.mapper.DraftDesignResponseMapper
-import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
-import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.getLongPathVariable
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.safetyBodyToMono
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.usecase.draftdesign.DraftDesignService
 import org.springframework.stereotype.Component
@@ -18,10 +18,7 @@ import java.util.stream.Collectors
 @Component
 class DraftDesignHandler(private val service: DraftDesignService) {
     fun saveDraft(request: ServerRequest): Mono<ServerResponse> {
-        val body: Mono<SaveDraftDesign.Request> = request
-            .bodyToMono(SaveDraftDesign.Request::class.java)
-            .onErrorResume { Mono.error(InvalidBodyException()) }
-            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val body = request.safetyBodyToMono(SaveDraftDesign.Request::class.java)
         val knitterId = AuthHelper.getKnitterId(request)
         return body
             .map { DraftDesignRequestMapper.toSaveDraftDesignData(it, knitterId) }
@@ -43,7 +40,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
 
     fun getMyDraftDesign(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val draftDesignId = request.pathVariable("draftDesignId").toLong()
+        val draftDesignId = request.getLongPathVariable("draftDesignId")
         return service
             .getMyDraftDesign(draftDesignId, knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -53,7 +50,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
 
     fun getMyDraftDesignToUpdate(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val designId = request.pathVariable("designId").toLong()
+        val designId = request.getLongPathVariable("designId")
         return service
             .getMyDraftDesignToUpdate(designId = designId, knitterId = knitterId)
             .doOnError(ExceptionHelper::raiseException)
@@ -63,7 +60,7 @@ class DraftDesignHandler(private val service: DraftDesignService) {
 
     fun deleteMyDraftDesign(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val draftDesignId = request.pathVariable("draftDesignId").toLong()
+        val draftDesignId = request.getLongPathVariable("draftDesignId")
         return service
             .deleteMyDraftDesign(draftDesignId, knitterId)
             .doOnError(ExceptionHelper::raiseException)

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/extension/ServerRequestExtension.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/extension/ServerRequestExtension.kt
@@ -1,0 +1,17 @@
+package com.kroffle.knitting.controller.handler.helper.extension
+
+import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
+import com.kroffle.knitting.controller.handler.exception.InvalidBodyException
+import org.springframework.web.reactive.function.server.ServerRequest
+import reactor.core.publisher.Mono
+
+object ServerRequestExtension {
+    fun <T> ServerRequest.safetyBodyToMono(clazz: Class<T>): Mono<T> =
+        this
+            .bodyToMono(clazz)
+            .onErrorResume { Mono.error(InvalidBodyException()) }
+            .switchIfEmpty(Mono.error(EmptyBodyException()))
+
+    fun ServerRequest.getLongPathVariable(key: String): Long =
+        this.pathVariable(key).toLong()
+}

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/ProductHandler.kt
@@ -1,8 +1,9 @@
 package com.kroffle.knitting.controller.handler.product
 
-import com.kroffle.knitting.controller.handler.exception.EmptyBodyException
 import com.kroffle.knitting.controller.handler.helper.auth.AuthHelper
 import com.kroffle.knitting.controller.handler.helper.exception.ExceptionHelper
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.getLongPathVariable
+import com.kroffle.knitting.controller.handler.helper.extension.ServerRequestExtension.safetyBodyToMono
 import com.kroffle.knitting.controller.handler.helper.pagination.PaginationHelper
 import com.kroffle.knitting.controller.handler.helper.response.ResponseHelper
 import com.kroffle.knitting.controller.handler.product.dto.EditProductContent
@@ -22,9 +23,7 @@ import java.util.stream.Collectors.toList
 class ProductHandler(private val productService: ProductService) {
     fun editProductPackage(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val bodyMono: Mono<EditProductPackage.Request> = request
-            .bodyToMono(EditProductPackage.Request::class.java)
-            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val bodyMono = request.safetyBodyToMono(EditProductPackage.Request::class.java)
 
         val product: Mono<Product> = bodyMono
             .map { ProductRequestMapper.toEditProductPackageData(it, knitterId) }
@@ -38,9 +37,7 @@ class ProductHandler(private val productService: ProductService) {
 
     fun editProductContent(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val bodyMono: Mono<EditProductContent.Request> = request
-            .bodyToMono(EditProductContent.Request::class.java)
-            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val bodyMono = request.safetyBodyToMono(EditProductContent.Request::class.java)
 
         val product: Mono<Product> = bodyMono
             .map { ProductRequestMapper.toEditProductContentData(it, knitterId) }
@@ -54,9 +51,7 @@ class ProductHandler(private val productService: ProductService) {
 
     fun registerProduct(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val bodyMono: Mono<RegisterProduct.Request> = request
-            .bodyToMono(RegisterProduct.Request::class.java)
-            .switchIfEmpty(Mono.error(EmptyBodyException()))
+        val bodyMono = request.safetyBodyToMono(RegisterProduct.Request::class.java)
 
         val product: Mono<Product> = bodyMono
             .map { ProductRequestMapper.toRegisterProductData(it, knitterId) }
@@ -70,7 +65,7 @@ class ProductHandler(private val productService: ProductService) {
 
     fun getMyProduct(request: ServerRequest): Mono<ServerResponse> {
         val knitterId = AuthHelper.getKnitterId(request)
-        val productId = request.pathVariable("productId").toLong()
+        val productId = request.getLongPathVariable("productId")
 
         return productService
             .get(ProductRequestMapper.toGetMyProductData(productId, knitterId))

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -20,6 +20,7 @@ class DesignsRouter(
             listOf(
                 GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
                 POST(CREATE_DESIGN_PATH, designHandler::createDesign),
+                PUT(UPDATE_DESIGN_PATH, designHandler::updateDesign),
             )
         }
     )
@@ -40,13 +41,17 @@ class DesignsRouter(
 
     companion object {
         private const val ROOT_PATH = "/designs"
+        // path of design router
         private const val GET_MY_DESIGNS_PATH = "/mine"
+        private const val CREATE_DESIGN_PATH = ""
+        private const val UPDATE_DESIGN_PATH = "/{designId}"
+        // path of draft design router
         private const val GET_MY_DRAFT_DESIGNS_PATH = "/draft/mine"
         private const val GET_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
         private const val GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH = "/{designId}/draft/mine"
-        private const val CREATE_DESIGN_PATH = ""
         private const val SAVE_DRAFT_PATH = "/draft"
         private const val DELETE_MY_DRAFT_DESIGN_PATH = "/draft/mine/{draftDesignId}"
+
         val PUBLIC_PATHS: List<String> = listOf()
     }
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouter.kt
@@ -19,10 +19,19 @@ class DesignsRouter(
         router {
             listOf(
                 GET(GET_MY_DESIGNS_PATH, designHandler::getMyDesigns),
+                POST(CREATE_DESIGN_PATH, designHandler::createDesign),
+            )
+        }
+    )
+
+    @Bean
+    fun draftDesignsRouterFunction() = nest(
+        path(ROOT_PATH),
+        router {
+            listOf(
                 GET(GET_MY_DRAFT_DESIGNS_PATH, draftDesignHandler::getMyDraftDesigns),
                 GET(GET_MY_DRAFT_DESIGN_PATH, draftDesignHandler::getMyDraftDesign),
                 GET(GET_MY_DRAFT_DESIGN_TO_UPDATE_PATH, draftDesignHandler::getMyDraftDesignToUpdate),
-                POST(CREATE_DESIGN_PATH, designHandler::createDesign),
                 POST(SAVE_DRAFT_PATH, draftDesignHandler::saveDraft),
                 DELETE(DELETE_MY_DRAFT_DESIGN_PATH, draftDesignHandler::deleteMyDraftDesign),
             )

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -43,6 +43,32 @@ data class Design(
         HARD
     }
 
+    fun update(
+        designType: DesignType,
+        patternType: PatternType,
+        gauge: Gauge,
+        size: Size,
+        needle: String,
+        yarn: String,
+        extra: String?,
+        pattern: Pattern,
+        description: String,
+        targetLevel: LevelType,
+        techniques: List<Technique>,
+    ) = this.copy(
+        designType = designType,
+        patternType = patternType,
+        gauge = gauge,
+        size = size,
+        needle = needle,
+        yarn = yarn,
+        extra = extra,
+        pattern = pattern,
+        description = description,
+        targetLevel = targetLevel,
+        techniques = techniques,
+    )
+
     companion object {
         fun new(
             knitterId: Long,

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
@@ -30,7 +30,7 @@ class DesignRepositoryImpl(
             .flatMap { getDesignAggregate(it) }
             .switchIfEmpty(Mono.error(NotFoundEntity(DesignEntity::class.java)))
 
-    override fun createDesign(design: Design): Mono<Design> =
+    private fun saveDesign(design: Design): Mono<Design> =
         designRepository
             .save(design.toDesignEntity())
             .flatMap { designEntity ->
@@ -57,6 +57,10 @@ class DesignRepositoryImpl(
                         designEntity.toDesign(techniques = it.t1, size = it.t2)
                     }
             }
+
+    override fun createDesign(design: Design): Mono<Design> = saveDesign(design)
+
+    override fun updateDesign(design: Design): Mono<Design> = saveDesign(design)
 
     private fun getDesignAggregates(designs: Flux<DesignEntity>): Flux<Design> {
         val designIds: Mono<List<Long>> =

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/repository/DesignRepositoryImpl.kt
@@ -24,6 +24,12 @@ class DesignRepositoryImpl(
     private val techniqueRepository: R2DBCTechniqueRepository,
     private val sizeRepository: R2DBCSizeRepository,
 ) : DesignRepository {
+    override fun getDesign(id: Long, knitterId: Long): Mono<Design> =
+        designRepository
+            .findByIdAndKnitterId(id, knitterId)
+            .flatMap { getDesignAggregate(it) }
+            .switchIfEmpty(Mono.error(NotFoundEntity(DesignEntity::class.java)))
+
     override fun createDesign(design: Design): Mono<Design> =
         designRepository
             .save(design.toDesignEntity())
@@ -129,10 +135,4 @@ class DesignRepositoryImpl(
         }
         return getDesignAggregates(designs)
     }
-
-    override fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<Design> =
-        designRepository
-            .findByIdAndKnitterId(id, knitterId)
-            .flatMap { getDesignAggregate(it) }
-            .switchIfEmpty(Mono.error(NotFoundEntity(DesignEntity::class.java)))
 }

--- a/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/UpdateDesignData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/design/dto/UpdateDesignData.kt
@@ -1,0 +1,24 @@
+package com.kroffle.knitting.usecase.design.dto
+
+import com.kroffle.knitting.domain.design.entity.Design
+import com.kroffle.knitting.domain.design.value.Gauge
+import com.kroffle.knitting.domain.design.value.Pattern
+import com.kroffle.knitting.domain.design.value.Size
+import com.kroffle.knitting.domain.design.value.Technique
+
+data class UpdateDesignData(
+    val id: Long,
+    val knitterId: Long,
+    val designType: Design.DesignType,
+    val patternType: Design.PatternType,
+    val gauge: Gauge,
+    val size: Size,
+    val needle: String,
+    val yarn: String,
+    val extra: String?,
+    val pattern: Pattern,
+    val description: String,
+    val targetLevel: Design.LevelType,
+    val techniques: List<Technique>,
+    val draftId: Long?,
+)

--- a/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
+++ b/src/main/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignService.kt
@@ -13,8 +13,7 @@ class DraftDesignService(
     private val designRepository: DesignRepository,
 ) {
     private fun verifyDesignId(designId: Long, knitterId: Long): Mono<Design> {
-        return designRepository
-            .findByIdAndKnitterId(designId, knitterId)
+        return designRepository.getDesign(designId, knitterId)
     }
 
     private fun saveDraftDesign(data: SaveDraftDesignData): Mono<DraftDesign> {
@@ -76,6 +75,6 @@ class DraftDesignService(
     }
 
     interface DesignRepository {
-        fun findByIdAndKnitterId(id: Long, knitterId: Long): Mono<Design>
+        fun getDesign(id: Long, knitterId: Long): Mono<Design>
     }
 }

--- a/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/handler/draftdesign/DraftDesignHandlerTest.kt
@@ -37,7 +37,7 @@ class DraftDesignHandlerTest : DescribeSpec() {
         val mockDraftDesignService = mockk<DraftDesignService>()
         val designsRouter = DesignsRouter(mockk(), DraftDesignHandler(mockDraftDesignService))
         val designsWebclient = WebTestClientHelper
-            .createWebTestClient(designsRouter.designsRouterFunction())
+            .createWebTestClient(designsRouter.draftDesignsRouterFunction())
 
         afterContainer { clearAllMocks() }
 

--- a/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
@@ -9,7 +9,9 @@ import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.MockData
 import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.WebTestClientHelper
+import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
+import com.kroffle.knitting.usecase.design.dto.UpdateDesignData
 import com.kroffle.knitting.usecase.repository.DesignRepository
 import com.kroffle.knitting.usecase.repository.DraftDesignRepository
 import io.kotest.core.spec.style.BehaviorSpec
@@ -19,6 +21,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import reactor.core.publisher.Mono
+import reactor.kotlin.test.expectError
+import reactor.kotlin.test.test
 
 class DesignServiceTest : BehaviorSpec() {
     init {
@@ -30,62 +34,12 @@ class DesignServiceTest : BehaviorSpec() {
             clearAllMocks()
         }
 
-        val baseCreateData = CreateDesignData(
-            knitterId = 1,
-            name = "도안 이름",
-            designType = Design.DesignType.Sweater,
-            patternType = Design.PatternType.Text,
-            gauge = Gauge(14.0, 15.5),
-            size = Size(
-                totalLength = Length(10.0),
-                sleeveLength = Length(10.0),
-                shoulderWidth = Length(10.0),
-                bottomWidth = Length(10.0),
-                armholeDepth = Length(10.0),
-            ),
-            needle = "둘레바늘 5.0mm 80cm",
-            yarn = "메리노울 캐시미어 합사",
-            extra = null,
-            price = Money.ZERO,
-            pattern = Pattern("코를 잡는다."),
-            description = "남녀공용 루즈핏 피셔맨니트",
-            targetLevel = Design.LevelType.NORMAL,
-            coverImageUrl = "http://mock.wordway.com/image.png",
-            techniques = emptyList(),
-            draftId = null,
-        )
-        val requestedDesign = Design(
-            id = null,
-            knitterId = 1,
-            name = "도안 이름",
-            designType = Design.DesignType.Sweater,
-            patternType = Design.PatternType.Text,
-            gauge = Gauge(14.0, 15.5),
-            size = Size(
-                totalLength = Length(10.0),
-                sleeveLength = Length(10.0),
-                shoulderWidth = Length(10.0),
-                bottomWidth = Length(10.0),
-                armholeDepth = Length(10.0),
-            ),
-            needle = "둘레바늘 5.0mm 80cm",
-            yarn = "메리노울 캐시미어 합사",
-            extra = null,
-            price = Money.ZERO,
-            pattern = Pattern("코를 잡는다."),
-            description = "남녀공용 루즈핏 피셔맨니트",
-            targetLevel = Design.LevelType.NORMAL,
-            coverImageUrl = "http://mock.wordway.com/image.png",
-            techniques = emptyList(),
-            createdAt = null,
-        )
-        val createdDesign = MockFactory.create(MockData.Design(id = 1))
+        Given("저장하고자 하는 도안에 임시저장 내역이 있고") {
+            val draftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
 
-        Given("저장하고자 하는 도안에") {
-
-            When("임시저장 내역이 있을 때") {
-                val createData = baseCreateData.copy(draftId = 1)
-                val draftDesign = MockFactory.create(MockData.DraftDesign(id = 1))
+            When("도안을 생성하면") {
+                val createdDesign = MockFactory.create(MockData.Design(id = 1))
+                val createData = createCreateDesignData().copy(draftId = 1)
 
                 every {
                     draftDesignRepository.getDraftDesign(any(), any())
@@ -118,15 +72,70 @@ class DesignServiceTest : BehaviorSpec() {
 
                 Then("도안 생성을 요청해야 한다") {
                     verify(exactly = 1) {
-                        designRepository.createDesign(requestedDesign)
+                        designRepository.createDesign(createDesignFromData(createData))
                     }
                 }
                 Then("생성된 도안을 반환해야 한다") {
                     result shouldBe createdDesign
                 }
             }
-            When("임시저장 내역이 없을 때") {
-                val createData = baseCreateData.copy(draftId = null)
+
+            When("도안을 수정하면") {
+                val designId: Long = 1
+                val draftDesignId: Long = 2
+                val updateData = createUpdateDesignData(designId).copy(draftId = draftDesignId)
+                val mockDesign = MockFactory.create(MockData.Design(id = designId))
+
+                every {
+                    draftDesignRepository.getDraftDesign(any(), any())
+                } returns Mono.just(draftDesign)
+
+                every {
+                    draftDesignRepository.delete(any())
+                } returns Mono.just(draftDesignId)
+
+                every {
+                    designRepository.updateDesign(any())
+                } returns Mono.just(mockDesign)
+
+                every {
+                    designRepository.getDesign(any(), any())
+                } returns Mono.just(mockDesign)
+
+                val result = service.update(updateData).block()
+
+                Then("유저가 해당 임시저장 내역을 가지고 있는지 확인해야 한다") {
+                    verify(exactly = 1) {
+                        draftDesignRepository.getDraftDesign(
+                            id = draftDesignId,
+                            knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
+                        )
+                    }
+                }
+
+                Then("임시저장 내역을 삭제해야 한다") {
+                    verify(exactly = 1) {
+                        draftDesignRepository.delete(draftDesign)
+                    }
+                }
+
+                Then("도안 수정을 요청해야 한다") {
+                    verify(exactly = 1) {
+                        val expectedParam = createDesignFromData(mockDesign, updateData)
+                        designRepository.updateDesign(expectedParam)
+                    }
+                }
+                Then("생성된 도안을 반환해야 한다") {
+                    result shouldBe mockDesign
+                }
+            }
+        }
+
+        Given("저장하고자 하는 도안에 임시저장 내역이 없고") {
+            When("도안을 생성하면") {
+                val createData = createCreateDesignData().copy(draftId = null)
+                val createdDesign = MockFactory.create(MockData.Design(id = 1))
+
                 every {
                     designRepository.createDesign(any())
                 } returns Mono.just(createdDesign)
@@ -135,13 +144,143 @@ class DesignServiceTest : BehaviorSpec() {
 
                 Then("도안 생성을 요청해야 한다") {
                     verify(exactly = 1) {
-                        designRepository.createDesign(requestedDesign)
+                        designRepository.createDesign(createDesignFromData(createData))
                     }
                 }
                 Then("생성된 도안을 반환해야 한다") {
                     result shouldBe createdDesign
                 }
             }
+
+            When("도안을 수정하면") {
+                val designId: Long = 1
+                val updateData = createUpdateDesignData(designId).copy(draftId = null)
+                val mockDesign = MockFactory.create(MockData.Design(id = designId))
+
+                every {
+                    designRepository.getDesign(any(), any())
+                } returns Mono.just(mockDesign)
+
+                every {
+                    designRepository.updateDesign(any())
+                } returns Mono.just(mockDesign)
+
+                val result = service.update(updateData).block()
+
+                Then("도안 생성을 요청해야 한다") {
+                    verify(exactly = 1) {
+                        val expectedParam = createDesignFromData(mockDesign, updateData)
+                        designRepository.updateDesign(expectedParam)
+                    }
+                }
+                Then("생성된 도안을 반환해야 한다") {
+                    result shouldBe mockDesign
+                }
+            }
+        }
+        Given("주어진 도안이 없고") {
+            every {
+                designRepository.getDesign(any(), any())
+            } returns Mono.error(NotFoundEntity(Design::class.java))
+            When("도안 수정을 요청할 때") {
+                val result = service.update(createUpdateDesignData(1)).test()
+                Then("작성 중이던 도안을 조회해와야 한다") {
+                    verify(exactly = 1) {
+                        designRepository.getDesign(1, 1)
+                    }
+                }
+                Then("NotFoundEntity exception 이 발생해야 한다") {
+                    result.expectError(NotFoundEntity::class).verify()
+                }
+            }
         }
     }
+
+    private fun createCreateDesignData() = CreateDesignData(
+        knitterId = 1,
+        name = "도안 이름",
+        designType = Design.DesignType.Sweater,
+        patternType = Design.PatternType.Text,
+        gauge = Gauge(14.0, 15.5),
+        size = Size(
+            totalLength = Length(10.0),
+            sleeveLength = Length(10.0),
+            shoulderWidth = Length(10.0),
+            bottomWidth = Length(10.0),
+            armholeDepth = Length(10.0),
+        ),
+        needle = "둘레바늘 5.0mm 80cm",
+        yarn = "메리노울 캐시미어 합사",
+        extra = null,
+        price = Money.ZERO,
+        pattern = Pattern("코를 잡는다."),
+        description = "남녀공용 루즈핏 피셔맨니트",
+        targetLevel = Design.LevelType.NORMAL,
+        coverImageUrl = "http://mock.wordway.com/image.png",
+        techniques = emptyList(),
+        draftId = null,
+    )
+
+    private fun createUpdateDesignData(designId: Long) = UpdateDesignData(
+        id = designId,
+        knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
+        designType = Design.DesignType.Sweater,
+        patternType = Design.PatternType.Text,
+        gauge = Gauge(14.0, 15.5),
+        size = Size(
+            totalLength = Length(10.0),
+            sleeveLength = Length(10.0),
+            shoulderWidth = Length(10.0),
+            bottomWidth = Length(10.0),
+            armholeDepth = Length(10.0),
+        ),
+        needle = "둘레바늘 5.0mm 80cm",
+        yarn = "메리노울 캐시미어 합사",
+        extra = null,
+        pattern = Pattern("코를 잡는다."),
+        description = "남녀공용 루즈핏 피셔맨니트",
+        targetLevel = Design.LevelType.NORMAL,
+        techniques = emptyList(),
+        draftId = null,
+    )
+
+    private fun createDesignFromData(data: CreateDesignData) =
+        with(data) {
+            Design(
+                id = null,
+                knitterId = WebTestClientHelper.AUTHORIZED_KNITTER_ID,
+                name = name,
+                designType = designType,
+                patternType = patternType,
+                gauge = gauge,
+                size = size,
+                needle = needle,
+                yarn = yarn,
+                extra = extra,
+                price = price,
+                pattern = pattern,
+                description = description,
+                targetLevel = targetLevel,
+                coverImageUrl = coverImageUrl,
+                techniques = techniques,
+                createdAt = null,
+            )
+        }
+
+    private fun createDesignFromData(design: Design, data: UpdateDesignData) =
+        with(data) {
+            design.update(
+                designType = designType,
+                patternType = patternType,
+                gauge = gauge,
+                size = size,
+                needle = needle,
+                yarn = yarn,
+                extra = extra,
+                pattern = pattern,
+                description = description,
+                targetLevel = targetLevel,
+                techniques = techniques,
+            )
+        }
 }

--- a/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/draftdesign/DraftDesignServiceTest.kt
@@ -247,7 +247,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 val saveArgument = slot<DraftDesign>()
 
                 every {
-                    mockDesignRepository.findByIdAndKnitterId(any(), any())
+                    mockDesignRepository.getDesign(any(), any())
                 } returns Mono.just(mockDesign)
 
                 every {
@@ -257,7 +257,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 val result = service.saveDraft(data).block()
                 Then("존재하는 도안인지 검증해야 한다") {
                     verify(exactly = 1) {
-                        mockDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDesignRepository.getDesign(1, 1)
                     }
                 }
                 Then("새로운 임시저장 내역을 생성해야 한다") {
@@ -288,7 +288,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 val saveArgument = slot<DraftDesign>()
 
                 every {
-                    mockDesignRepository.findByIdAndKnitterId(any(), any())
+                    mockDesignRepository.getDesign(any(), any())
                 } returns Mono.just(mockDesign)
 
                 every {
@@ -303,7 +303,7 @@ class DraftDesignServiceTest : BehaviorSpec() {
                 val result = service.saveDraft(data).block()
                 Then("존재하는 도안인지 검증해야 한다") {
                     verify(exactly = 1) {
-                        mockDesignRepository.findByIdAndKnitterId(1, 1)
+                        mockDesignRepository.getDesign(1, 1)
                     }
                 }
                 Then("기존 임시저장 내역을 조회해야 한다") {


### PR DESCRIPTION
## PR 제안 사유
- 도안 수정한 내용을 저장할 수 있도록 합니다. 
- 수정 불가능 영역을 잡은 기준은 두가지이고 해당되는 필드는 세가지입니다.
  - 도안을 식별하는데 필요한 부분 (이름과 대표이미지가 포함됩니다.)
  - 결제하는데 필요한 부분 (가격이 포함됩니다.) 
- [API 문서 바로가기](https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-fa633394-2432-41a7-9b75-37a238ca2816)
- 클라이언트에서는 [이렇게](https://app.clickup.com/t/1wfjzc4?comment=829639083) 처리해주면 될 것 같아요~

Resolves [#1wfjzc4](https://app.clickup.com/t/1wfjzc4)

## 주요 변경 기록
- design, draft-design router bean 분리
- 자주 사용하는 ServerRequest 로직 extension 분리
- design 수정 가능한 도메인 함수 정의
- 중복되는 dto 분리
- 도안 수정 API 구현
- 각종 리팩토링
  - 함수 이름 변경
  - 로직 리팩토링 
