### PR TITLE
feat: design 도메인에서 updated_at 관리할 수 있도록 추가

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/entity/Design.kt
@@ -24,6 +24,7 @@ data class Design(
     val targetLevel: LevelType,
     val coverImageUrl: String,
     val techniques: List<Technique>,
+    val updatedAt: OffsetDateTime?,
     val createdAt: OffsetDateTime?,
 ) {
     enum class DesignType(val code: Int, val tag: String) {
@@ -67,6 +68,7 @@ data class Design(
         description = description,
         targetLevel = targetLevel,
         techniques = techniques,
+        updatedAt = OffsetDateTime.now(),
     )
 
     companion object {
@@ -103,6 +105,7 @@ data class Design(
             targetLevel = targetLevel,
             coverImageUrl = coverImageUrl,
             techniques = techniques,
+            updatedAt = null,
             createdAt = null,
         )
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/persistence/design/entity/DesignEntity.kt
@@ -27,6 +27,7 @@ class DesignEntity(
     private val description: String,
     private val targetLevel: String,
     private val coverImageUrl: String,
+    private val updatedAt: OffsetDateTime = OffsetDateTime.now(),
     private val createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) {
     fun getNotNullId(): Long = id!!
@@ -49,6 +50,7 @@ class DesignEntity(
             targetLevel = Design.LevelType.valueOf(this.targetLevel),
             coverImageUrl = this.coverImageUrl,
             techniques = techniques,
+            updatedAt = this.updatedAt,
             createdAt = this.createdAt,
         )
 }
@@ -70,5 +72,6 @@ fun Design.toDesignEntity() =
         description = this.description,
         targetLevel = this.targetLevel.name,
         coverImageUrl = this.coverImageUrl,
+        updatedAt = this.updatedAt ?: OffsetDateTime.now(),
         createdAt = this.createdAt ?: OffsetDateTime.now(),
     )

--- a/src/main/resources/db/migration/V12__add_updated_at_to_design.sql
+++ b/src/main/resources/db/migration/V12__add_updated_at_to_design.sql
@@ -1,0 +1,5 @@
+ALTER TABLE design ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE design SET updated_at = created_at;
+
+ALTER TABLE design ALTER COLUMN updated_at SET NOT NULL;

--- a/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/controller/router/design/DesignsRouterTest.kt
@@ -98,6 +98,7 @@ class DesignsRouterTest {
                         targetLevel = Design.LevelType.HARD,
                         coverImageUrl = "http://test.kroffle.com/image.jpg",
                         techniques = listOf(Technique("안뜨기"), Technique("겉뜨기")),
+                        updatedAt = today,
                         createdAt = today,
                     )
                 )

--- a/src/test/kotlin/com/kroffle/knitting/helper/MockData.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/MockData.kt
@@ -56,6 +56,7 @@ object MockData {
         val targetLevel: LevelType = LevelType.EASY,
         val coverImageUrl: String = "https://mock.wordway.com/image.png",
         val techniques: List<Technique> = listOf(),
+        val updatedAt: OffsetDateTime? = OffsetDateTime.now(),
         val createdAt: OffsetDateTime? = OffsetDateTime.now(),
     )
     data class DraftDesign(

--- a/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/MockFactory.kt
@@ -45,6 +45,7 @@ class MockFactory {
                     targetLevel = targetLevel,
                     coverImageUrl = coverImageUrl,
                     techniques = techniques,
+                    updatedAt = updatedAt,
                     createdAt = createdAt,
                 )
             }

--- a/src/test/kotlin/com/kroffle/knitting/helper/mocker/TimeMocker.kt
+++ b/src/test/kotlin/com/kroffle/knitting/helper/mocker/TimeMocker.kt
@@ -1,0 +1,26 @@
+package com.kroffle.knitting.helper.mocker
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+object TimeMocker {
+    private val mockingDate: OffsetDateTime = OffsetDateTime.of(
+        2022,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        ZoneOffset.UTC
+    )
+
+    fun mockOffsetDateTime() {
+        mockkStatic(OffsetDateTime::class)
+        every {
+            OffsetDateTime.now()
+        } returns mockingDate
+    }
+}

--- a/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
+++ b/src/test/kotlin/com/kroffle/knitting/usecase/design/DesignServiceTest.kt
@@ -9,6 +9,7 @@ import com.kroffle.knitting.domain.value.Money
 import com.kroffle.knitting.helper.MockData
 import com.kroffle.knitting.helper.MockFactory
 import com.kroffle.knitting.helper.WebTestClientHelper
+import com.kroffle.knitting.helper.mocker.TimeMocker.mockOffsetDateTime
 import com.kroffle.knitting.infra.persistence.exception.NotFoundEntity
 import com.kroffle.knitting.usecase.design.dto.CreateDesignData
 import com.kroffle.knitting.usecase.design.dto.UpdateDesignData
@@ -29,6 +30,10 @@ class DesignServiceTest : BehaviorSpec() {
         val designRepository = mockk<DesignRepository>()
         val draftDesignRepository = mockk<DraftDesignRepository>()
         val service = DesignService(designRepository, draftDesignRepository)
+
+        beforeContainer {
+            mockOffsetDateTime()
+        }
 
         afterContainer {
             clearAllMocks()
@@ -71,8 +76,9 @@ class DesignServiceTest : BehaviorSpec() {
                 }
 
                 Then("도안 생성을 요청해야 한다") {
+                    val expectedParam = createDesignFromData(createData)
                     verify(exactly = 1) {
-                        designRepository.createDesign(createDesignFromData(createData))
+                        designRepository.createDesign(expectedParam)
                     }
                 }
                 Then("생성된 도안을 반환해야 한다") {
@@ -120,8 +126,8 @@ class DesignServiceTest : BehaviorSpec() {
                 }
 
                 Then("도안 수정을 요청해야 한다") {
+                    val expectedParam = createDesignFromData(mockDesign, updateData)
                     verify(exactly = 1) {
-                        val expectedParam = createDesignFromData(mockDesign, updateData)
                         designRepository.updateDesign(expectedParam)
                     }
                 }
@@ -168,8 +174,8 @@ class DesignServiceTest : BehaviorSpec() {
                 val result = service.update(updateData).block()
 
                 Then("도안 생성을 요청해야 한다") {
+                    val expectedParam = createDesignFromData(mockDesign, updateData)
                     verify(exactly = 1) {
-                        val expectedParam = createDesignFromData(mockDesign, updateData)
                         designRepository.updateDesign(expectedParam)
                     }
                 }
@@ -263,6 +269,7 @@ class DesignServiceTest : BehaviorSpec() {
                 targetLevel = targetLevel,
                 coverImageUrl = coverImageUrl,
                 techniques = techniques,
+                updatedAt = null,
                 createdAt = null,
             )
         }


### PR DESCRIPTION
## PR 제안 사유
- 도안 변경 시간을 버전으로 삼을 것이기 때문에 updated_at 컬럼을 추가하고 관리합니다.

Resolves #21vcmke

## 주요 변경 기록
- updated_at 컬럼 추가
- updated_at 필드 추가
- 깨지는 테스트 수정