### PR TITLE
refactor: JsonNaming 어노테이션 사용하도록 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesigns.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/MyDesigns.kt
@@ -1,18 +1,18 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
 import java.time.OffsetDateTime
 
 object MyDesigns {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Response(
         val id: Long,
         val name: String,
         val yarn: String,
-        @JsonProperty("cover_image_url")
         val coverImageUrl: String,
         val tags: List<String>,
-        @JsonProperty("created_at")
         val createdAt: OffsetDateTime,
     ) : ListItemPayload {
         override fun getCursor(): String = id.toString()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/NewDesign.kt
@@ -1,15 +1,15 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import com.kroffle.knitting.domain.design.entity.Design
 
 object NewDesign {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
         val name: String,
-        @JsonProperty("design_type")
         val designType: Design.DesignType,
-        @JsonProperty("pattern_type")
         val patternType: Design.PatternType,
         val stitches: Double,
         val rows: Double,
@@ -20,12 +20,9 @@ object NewDesign {
         val price: Int,
         val pattern: String,
         val description: String,
-        @JsonProperty("target_level")
         val targetLevel: Design.LevelType,
-        @JsonProperty("cover_image_url")
         val coverImageUrl: String,
         val techniques: List<String>,
-        @JsonProperty("draft_id")
         val draftId: Long?,
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SizeDto.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/SizeDto.kt
@@ -1,19 +1,15 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.domain.design.value.Length
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class SizeDto(
-    @JsonProperty("size_unit")
     val sizeUnit: Length.Unit = Length.Unit.Cm,
-    @JsonProperty("total_length")
     val totalLength: Double,
-    @JsonProperty("sleeve_length")
     val sleeveLength: Double,
-    @JsonProperty("shoulder_width")
     val shoulderWidth: Double,
-    @JsonProperty("bottom_width")
     val bottomWidth: Double,
-    @JsonProperty("armhole_depth")
     val armholeDepth: Double,
 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/UpdateDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/design/dto/UpdateDesign.kt
@@ -1,14 +1,14 @@
 package com.kroffle.knitting.controller.handler.design.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import com.kroffle.knitting.domain.design.entity.Design
 
 object UpdateDesign {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
-        @JsonProperty("design_type")
         val designType: Design.DesignType,
-        @JsonProperty("pattern_type")
         val patternType: Design.PatternType,
         val stitches: Double,
         val rows: Double,
@@ -18,10 +18,8 @@ object UpdateDesign {
         val extra: String?,
         val pattern: String,
         val description: String,
-        @JsonProperty("target_level")
         val targetLevel: Design.LevelType,
         val techniques: List<String>,
-        @JsonProperty("draft_id")
         val draftId: Long?,
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/SaveDraftDesign.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftdesign/dto/SaveDraftDesign.kt
@@ -1,12 +1,13 @@
 package com.kroffle.knitting.controller.handler.draftdesign.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 object SaveDraftDesign {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
         val id: Long?,
-        @JsonProperty("design_id")
         val designId: Long?,
         val value: String,
     )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/draftproduct/dto/SaveDraftProduct.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/draftproduct/dto/SaveDraftProduct.kt
@@ -1,12 +1,13 @@
 package com.kroffle.knitting.controller.handler.draftproduct.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 object SaveDraftProduct {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
         val id: Long?,
-        @JsonProperty("product_id")
         val productId: Long?,
         val value: String,
     )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/helper/response/type/MetaData.kt
@@ -1,10 +1,11 @@
 package com.kroffle.knitting.controller.handler.helper.response.type
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 class MetaData(
-    @JsonProperty("last_cursor")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val lastCursor: String? = null,
 )

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/MyProfile.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/MyProfile.kt
@@ -1,12 +1,13 @@
 package com.kroffle.knitting.controller.handler.knitter.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 object MyProfile {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Response(
         val email: String,
-        @JsonProperty("profile_image_url")
         val profileImageUrl: String?,
         val name: String?,
     ) : ObjectPayload

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummary.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/knitter/dto/SalesSummary.kt
@@ -1,13 +1,13 @@
 package com.kroffle.knitting.controller.handler.knitter.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 
 object SalesSummary {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Response(
-        @JsonProperty("number_of_products_on_sales")
         val numberOfProductsOnSales: Long,
-        @JsonProperty("number_of_products_sold")
         val numberOfProductsSold: Long,
     ) : ObjectPayload
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/CreateProduct.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/CreateProduct.kt
@@ -1,27 +1,22 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.OffsetDateTime
 
 object CreateProduct {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
-        @JsonProperty("design_ids")
         val designIds: List<Long>,
         val name: String,
-        @JsonProperty("full_price")
         val fullPrice: Int,
-        @JsonProperty("discount_price")
         val discountPrice: Int,
-        @JsonProperty("representative_image_url")
         val representativeImageUrl: String,
-        @JsonProperty("specified_sales_start_date")
         val specifiedSalesStartDate: OffsetDateTime?,
-        @JsonProperty("specified_sales_end_date")
         val specifiedSalesEndDate: OffsetDateTime?,
         val tags: List<String>,
         val content: String,
-        @JsonProperty("draft_id")
         val draftId: Long?,
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/EditProductPackage.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/EditProductPackage.kt
@@ -1,25 +1,21 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.LocalDate
 
 object EditProductPackage {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
         val id: Long?,
         val name: String,
-        @JsonProperty("full_price")
         val fullPrice: Int,
-        @JsonProperty("discount_price")
         val discountPrice: Int,
-        @JsonProperty("representative_image_url")
         val representativeImageUrl: String,
-        @JsonProperty("specified_sales_start_date")
         val specifiedSalesStartDate: LocalDate?,
-        @JsonProperty("specified_sales_end_date")
         val specifiedSalesEndDate: LocalDate?,
         val tags: List<String>,
-        @JsonProperty("design_ids")
         val designIds: List<Long>,
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProduct.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProduct.kt
@@ -1,32 +1,26 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
 object GetMyProduct {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Response(
         val id: Long,
         val name: String,
-        @JsonProperty("full_price")
         val fullPrice: Int,
-        @JsonProperty("discount_price")
         val discountPrice: Int,
-        @JsonProperty("representative_image_url")
         val representativeImageUrl: String,
-        @JsonProperty("specified_sales_start_date")
         val specifiedSalesStartDate: LocalDate?,
-        @JsonProperty("specified_sales_end_date")
         val specifiedSalesEndDate: LocalDate?,
         val tags: List<String>,
         val content: String?,
-        @JsonProperty("input_status")
         val inputStatus: String,
         val itemIds: List<Long>,
-        @JsonProperty("created_at")
         val createdAt: OffsetDateTime?,
-        @JsonProperty("updated_at")
         val updatedAt: OffsetDateTime?,
     ) : ObjectPayload
 }

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProducts.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/GetMyProducts.kt
@@ -1,28 +1,23 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ListItemPayload
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
 object GetMyProducts {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Response(
         val id: Long,
         val name: String,
-        @JsonProperty("full_price")
         val fullPrice: Int,
-        @JsonProperty("discount_price")
         val discountPrice: Int,
-        @JsonProperty("representative_image_url")
         val representativeImageUrl: String,
-        @JsonProperty("specified_sales_start_date")
         val specifiedSalesStartDate: LocalDate?,
-        @JsonProperty("specified_sales_end_date")
         val specifiedSalesEndDate: LocalDate?,
         val tags: List<String>,
-        @JsonProperty("input_status")
         val inputStatus: String,
-        @JsonProperty("updated_at")
         val updatedAt: OffsetDateTime?,
     ) : ListItemPayload {
         override fun getCursor(): String = updatedAt.toString()

--- a/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/UpdateProduct.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/handler/product/dto/UpdateProduct.kt
@@ -1,21 +1,19 @@
 package com.kroffle.knitting.controller.handler.product.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.kroffle.knitting.controller.handler.helper.response.type.ObjectPayload
 import java.time.OffsetDateTime
 
 // TODO: 수정 가능한 범위 정하기 with 해선
 object UpdateProduct {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Request(
-        @JsonProperty("discount_price")
         val discountPrice: Int,
-        @JsonProperty("specified_sales_start_date")
         val specifiedSalesStartDate: OffsetDateTime?,
-        @JsonProperty("specified_sales_end_date")
         val specifiedSalesEndDate: OffsetDateTime?,
         val tags: List<String>,
         val content: String,
-        @JsonProperty("draft_id")
         val draftId: Long?,
     )
 

--- a/src/main/kotlin/com/kroffle/knitting/domain/design/value/Size.kt
+++ b/src/main/kotlin/com/kroffle/knitting/domain/design/value/Size.kt
@@ -1,5 +1,9 @@
 package com.kroffle.knitting.domain.design.value
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class Size(
     val totalLength: Length,
     val sleeveLength: Length,

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/GoogleOAuthHelperImpl.kt
@@ -1,9 +1,9 @@
 package com.kroffle.knitting.infra.oauth
 
 import com.kroffle.knitting.infra.oauth.dto.ClientInfo
-import com.kroffle.knitting.infra.oauth.dto.GoogleAccessTokenResponse
+import com.kroffle.knitting.infra.oauth.dto.GoogleAccessToken
 import com.kroffle.knitting.infra.oauth.dto.GoogleOAuthConfig
-import com.kroffle.knitting.infra.oauth.dto.GoogleProfileResponse
+import com.kroffle.knitting.infra.oauth.dto.GoogleProfile
 import com.kroffle.knitting.infra.oauth.exception.InvalidGoogleAccessToken
 import com.kroffle.knitting.infra.oauth.exception.InvalidGoogleCode
 import com.kroffle.knitting.infra.oauth.exception.UnavailableGoogle
@@ -53,7 +53,7 @@ class GoogleOAuthHelperImpl(
                     else -> throw UnavailableGoogle()
                 }
             }
-            .bodyToMono<GoogleAccessTokenResponse>()
+            .bodyToMono<GoogleAccessToken.Response>()
             .flatMap {
                 Mono.just(it.accessToken)
             }
@@ -93,15 +93,17 @@ class GoogleOAuthHelperImpl(
                         else -> throw UnavailableGoogle()
                     }
                 }
-                .bodyToMono(GoogleProfileResponse::class.java)
-                .flatMap {
-                    Mono.just(
-                        OAuthProfile(
-                            email = it.email,
-                            name = it.name,
-                            profileImageUrl = it.picture,
+                .bodyToMono(GoogleProfile.Response::class.java)
+                .flatMap { response ->
+                    with(response) {
+                        Mono.just(
+                            OAuthProfile(
+                                email = email,
+                                name = name,
+                                profileImageUrl = picture,
+                            )
                         )
-                    )
+                    }
                 }
         }
     }

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleAccessToken.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleAccessToken.kt
@@ -1,0 +1,11 @@
+package com.kroffle.knitting.infra.oauth.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+object GoogleAccessToken {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+    data class Response(
+        val accessToken: String,
+    )
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleAccessTokenResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleAccessTokenResponse.kt
@@ -1,8 +1,0 @@
-package com.kroffle.knitting.infra.oauth.dto
-
-import com.fasterxml.jackson.annotation.JsonProperty
-
-data class GoogleAccessTokenResponse(
-    @JsonProperty("access_token")
-    val accessToken: String,
-)

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleProfile.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleProfile.kt
@@ -1,0 +1,9 @@
+package com.kroffle.knitting.infra.oauth.dto
+
+object GoogleProfile {
+    data class Response(
+        val email: String,
+        val name: String,
+        val picture: String,
+    )
+}

--- a/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleProfileResponse.kt
+++ b/src/main/kotlin/com/kroffle/knitting/infra/oauth/dto/GoogleProfileResponse.kt
@@ -1,7 +1,0 @@
-package com.kroffle.knitting.infra.oauth.dto
-
-data class GoogleProfileResponse(
-    val email: String,
-    val name: String,
-    val picture: String,
-)


### PR DESCRIPTION
## PR 제안 사유
@JsonProperty 대신 @JsonNaming을 이용할 수 있도록 수정합니다.


@YuuRiLee @jiyaaany snake_case가 아니라 camelCase로 요청을 해야하거나 응답이 오는 경우 반드시 알려주세요~!