### PR TITLE
chore: ssl 인증서 갱신을 위해 인증 path 변경

### DIFF
--- a/src/main/kotlin/com/kroffle/knitting/controller/router/auth/CertRouter.kt
+++ b/src/main/kotlin/com/kroffle/knitting/controller/router/auth/CertRouter.kt
@@ -21,7 +21,7 @@ class CertRouter(private val handler: CertHandler) {
 
     companion object {
         private const val ROOT_PATH = "/"
-        private const val APPLY_HTTPS_PATH = ".well-known/acme-challenge/o7DtLtR3ccPKK71iDectTrZC6tftXInhTFDAuDNgYI0"
+        private const val APPLY_HTTPS_PATH = ".well-known/acme-challenge/Fk4ql_Mo4IDQ9i6AwKS3p2WtrLu5456uHLmP1XKt-ts"
         val PUBLIC_PATHS = listOf(
             "$ROOT_PATH$APPLY_HTTPS_PATH",
         )


### PR DESCRIPTION
## PR 제안 사유

https가 만료되어 갱신하기 위한 과정입니다.
아래 Path로 요청시 secret 값을 리턴하도록 해야하므로 기존 path를 수정합니다.

```bash
$ certbot certonly --manual --email team.kroffle@gmail.com -d wordway.cafe24.com

-- 생략

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Create a file containing just this data:

<-secret->

And make it available on your web server at this URL:

http://wordway.cafe24.com/.well-known/acme-challenge/Fk4ql_Mo4IDQ9i6AwKS3p2WtrLu5456uHLmP1XKt-ts

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```
Resolves #2ayz4fj