### PR TITLE
ssl 인증서 갱신을 위해 http로 요청 받을 수 있도록 수정

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -79,7 +79,7 @@ jobs:
             docker login -u dragonyool -p ${{ secrets.DOCKERHUB_PASSWORD }}
             docker pull dragonyool/knitting-service:latest
             docker stop knitting-service
-            docker run -d -p 443:8080 --rm --name knitting-service -v /home/docker:/home dragonyool/knitting-service:latest
+            docker run -d -p 80:8080 --rm --name knitting-service -v /home/docker:/home dragonyool/knitting-service:latest
             docker logout
 
       - name: notify slack

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 logging.level.org.springframework.data.r2dbc=DEBUG
 
-server.ssl.enabled=true
+server.ssl.enabled=false
 server.ssl.key-store=/home/letsencrypt.jks
 server.ssl.key-store-password=${KNITTING_SSL_KEY_STORE_PASSWORD}
 server.ssl.key-password=${KNITTING_SSL_KEY_PASSWORD}


### PR DESCRIPTION
## PR 제안 사유

인증하기 위해서는 http로 통신할 수 있어야 하기 때문에 설정을 수정합니다.
인증서 갱신 후 rollback 해야 합니다.

관련 PR: https://github.com/k-roffle/knitting-service/pull/176

Resolves #2ayz4fj

