### PR TITLE
chore: add restart=always option at docker run command

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -79,7 +79,7 @@ jobs:
             docker login -u dragonyool -p ${{ secrets.DOCKERHUB_PASSWORD }}
             docker pull dragonyool/knitting-service:latest
             docker stop knitting-service
-            docker run -d -p 443:8080 --rm --name knitting-service -v /home/docker:/home dragonyool/knitting-service:latest
+            docker run -d -p 443:8080 --rm --name knitting-service -v /home/docker:/home dragonyool/knitting-service:latest --restart=always
             docker logout
 
       - name: notify slack


### PR DESCRIPTION
## PR 제안 사유
서버가 죽더라도 자동으로 docker container를 다시 재시작할 수 있도록 option을 추가합니다.
이러면 어느날 보니 서버가 죽어있고 그런날은 줄어들겠죠..? ㅠㅠ

Resolves #2ayz4ee
